### PR TITLE
Update MSI mapping classes to satisfy pep8

### DIFF
--- a/bapsflib/_hdf_mappers/__init__.py
+++ b/bapsflib/_hdf_mappers/__init__.py
@@ -21,6 +21,6 @@ mapping :ibf:`Digitizer` HDF5 groups, and
 """
 from .controls import HDFMapControls
 from .map_digitizers import hdfMap_digitizers
-from .msi import hdfMap_msi
+from .msi import HDFMapMSI
 
-__all__ = ['HDFMapControls', 'hdfMap_digitizers', 'hdfMap_msi']
+__all__ = ['HDFMapControls', 'hdfMap_digitizers', 'HDFMapMSI']

--- a/bapsflib/_hdf_mappers/msi/__init__.py
+++ b/bapsflib/_hdf_mappers/msi/__init__.py
@@ -8,4 +8,4 @@
 # License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
 #   license terms and contributor agreement.
 #
-from .map_msi import hdfMap_msi
+from .map_msi import HDFMapMSI

--- a/bapsflib/_hdf_mappers/msi/discharge.py
+++ b/bapsflib/_hdf_mappers/msi/discharge.py
@@ -31,7 +31,7 @@ class HDFMapMSIDischarge(HDFMapMSITemplate):
         |   +-- Discharge summary
 
     """
-    def __init__(self, group):
+    def __init__(self, group: h5py.Group):
         """
         :param group: the HDF5 MSI diagnostic group
         :type group: :class:`h5py.Group`

--- a/bapsflib/_hdf_mappers/msi/discharge.py
+++ b/bapsflib/_hdf_mappers/msi/discharge.py
@@ -14,10 +14,10 @@ import numpy as np
 from bapsflib.utils.errors import HDFMappingError
 from warnings import warn
 
-from .templates import hdfMap_msi_template
+from .templates import HDFMapMSITemplate
 
 
-class hdfMap_msi_discharge(hdfMap_msi_template):
+class hdfMap_msi_discharge(HDFMapMSITemplate):
     """
     Mapping class for the 'Discharge' MSI diagnostic.
 
@@ -37,7 +37,7 @@ class hdfMap_msi_discharge(hdfMap_msi_template):
         :type group: :class:`h5py.Group`
         """
         # initialize
-        hdfMap_msi_template.__init__(self, group)
+        HDFMapMSITemplate.__init__(self, group)
 
         # populate self.configs
         self._build_configs()

--- a/bapsflib/_hdf_mappers/msi/discharge.py
+++ b/bapsflib/_hdf_mappers/msi/discharge.py
@@ -17,7 +17,7 @@ from warnings import warn
 from .templates import HDFMapMSITemplate
 
 
-class hdfMap_msi_discharge(HDFMapMSITemplate):
+class HDFMapMSIDischarge(HDFMapMSITemplate):
     """
     Mapping class for the 'Discharge' MSI diagnostic.
 

--- a/bapsflib/_hdf_mappers/msi/gaspressure.py
+++ b/bapsflib/_hdf_mappers/msi/gaspressure.py
@@ -17,7 +17,7 @@ from warnings import warn
 from .templates import HDFMapMSITemplate
 
 
-class hdfMap_msi_gaspressure(HDFMapMSITemplate):
+class HDFMapMSIGasPressure(HDFMapMSITemplate):
     """
     Mapping class for the 'Gas pressure' MSI diagnostic.
 

--- a/bapsflib/_hdf_mappers/msi/gaspressure.py
+++ b/bapsflib/_hdf_mappers/msi/gaspressure.py
@@ -30,7 +30,7 @@ class HDFMapMSIGasPressure(HDFMapMSITemplate):
         |   +-- RGA partial pressures
 
     """
-    def __init__(self, group):
+    def __init__(self, group: h5py.Group):
         """
         :param group: the HDF5 MSI diagnostic group
         :type group: :class:`h5py.Group`

--- a/bapsflib/_hdf_mappers/msi/gaspressure.py
+++ b/bapsflib/_hdf_mappers/msi/gaspressure.py
@@ -14,10 +14,10 @@ import numpy as np
 from bapsflib.utils.errors import HDFMappingError
 from warnings import warn
 
-from .templates import hdfMap_msi_template
+from .templates import HDFMapMSITemplate
 
 
-class hdfMap_msi_gaspressure(hdfMap_msi_template):
+class hdfMap_msi_gaspressure(HDFMapMSITemplate):
     """
     Mapping class for the 'Gas pressure' MSI diagnostic.
 
@@ -36,7 +36,7 @@ class hdfMap_msi_gaspressure(hdfMap_msi_template):
         :type group: :class:`h5py.Group`
         """
         # initialize
-        hdfMap_msi_template.__init__(self, group)
+        HDFMapMSITemplate.__init__(self, group)
 
         # populate self.configs
         self._build_configs()

--- a/bapsflib/_hdf_mappers/msi/heater.py
+++ b/bapsflib/_hdf_mappers/msi/heater.py
@@ -29,7 +29,7 @@ class HDFMapMSIHeater(HDFMapMSITemplate):
         |   +-- Heater summary
 
     """
-    def __init__(self, group):
+    def __init__(self, group: h5py.Group):
         """
         :param group: the HDF5 MSI diagnostic group
         :type group: :class:`h5py.Group`

--- a/bapsflib/_hdf_mappers/msi/heater.py
+++ b/bapsflib/_hdf_mappers/msi/heater.py
@@ -14,10 +14,10 @@ import numpy as np
 from bapsflib.utils.errors import HDFMappingError
 from warnings import warn
 
-from .templates import hdfMap_msi_template
+from .templates import HDFMapMSITemplate
 
 
-class hdfMap_msi_heater(hdfMap_msi_template):
+class hdfMap_msi_heater(HDFMapMSITemplate):
     """
     Mapping class for the 'Heater' MSI diagnostic.
 
@@ -35,7 +35,7 @@ class hdfMap_msi_heater(hdfMap_msi_template):
         :type group: :class:`h5py.Group`
         """
         # initialize
-        hdfMap_msi_template.__init__(self, group)
+        HDFMapMSITemplate.__init__(self, group)
 
         # populate self.configs
         self._build_configs()

--- a/bapsflib/_hdf_mappers/msi/heater.py
+++ b/bapsflib/_hdf_mappers/msi/heater.py
@@ -17,7 +17,7 @@ from warnings import warn
 from .templates import HDFMapMSITemplate
 
 
-class hdfMap_msi_heater(HDFMapMSITemplate):
+class HDFMapMSIHeater(HDFMapMSITemplate):
     """
     Mapping class for the 'Heater' MSI diagnostic.
 

--- a/bapsflib/_hdf_mappers/msi/interferometerarray.py
+++ b/bapsflib/_hdf_mappers/msi/interferometerarray.py
@@ -39,7 +39,7 @@ class HDFMapMSIInterferometerArray(HDFMapMSITemplate):
         |   |   +-- Interferometer summary list
         |   |   +-- Interferometer trace
     """
-    def __init__(self, group):
+    def __init__(self, group: h5py.Group):
         """
         :param group: the HDF5 MSI diagnostic group
         :type group: :class:`h5py.Group`

--- a/bapsflib/_hdf_mappers/msi/interferometerarray.py
+++ b/bapsflib/_hdf_mappers/msi/interferometerarray.py
@@ -14,11 +14,11 @@ import numpy as np
 from bapsflib.utils.errors import HDFMappingError
 from warnings import warn
 
-from .templates import hdfMap_msi_template
+from .templates import HDFMapMSITemplate
 
 
 # noinspection PyPep8Naming
-class hdfMap_msi_interarr(hdfMap_msi_template):
+class hdfMap_msi_interarr(HDFMapMSITemplate):
     """
     Mapping class for the 'Interferometer array' MSI diagnostic.
 
@@ -46,7 +46,7 @@ class hdfMap_msi_interarr(hdfMap_msi_template):
         :type group: :class:`h5py.Group`
         """
         # initialize
-        hdfMap_msi_template.__init__(self, group)
+        HDFMapMSITemplate.__init__(self, group)
 
         # populate self.configs
         self._build_configs()

--- a/bapsflib/_hdf_mappers/msi/interferometerarray.py
+++ b/bapsflib/_hdf_mappers/msi/interferometerarray.py
@@ -17,7 +17,6 @@ from warnings import warn
 from .templates import HDFMapMSITemplate
 
 
-# noinspection PyPep8Naming
 class HDFMapMSIInterferometerArray(HDFMapMSITemplate):
     """
     Mapping class for the 'Interferometer array' MSI diagnostic.

--- a/bapsflib/_hdf_mappers/msi/interferometerarray.py
+++ b/bapsflib/_hdf_mappers/msi/interferometerarray.py
@@ -18,7 +18,7 @@ from .templates import HDFMapMSITemplate
 
 
 # noinspection PyPep8Naming
-class hdfMap_msi_interarr(HDFMapMSITemplate):
+class HDFMapMSIInterferometerArray(HDFMapMSITemplate):
     """
     Mapping class for the 'Interferometer array' MSI diagnostic.
 

--- a/bapsflib/_hdf_mappers/msi/magneticfield.py
+++ b/bapsflib/_hdf_mappers/msi/magneticfield.py
@@ -30,7 +30,7 @@ class HDFMapMSIMagneticField(HDFMapMSITemplate):
         |   +-- Magnetic field profile
         |   +-- Magnetic field summary
     """
-    def __init__(self, group):
+    def __init__(self, group: h5py.Group):
         """
         :param group: the HDF5 MSI diagnostic group
         :type group: :class:`h5py.Group`

--- a/bapsflib/_hdf_mappers/msi/magneticfield.py
+++ b/bapsflib/_hdf_mappers/msi/magneticfield.py
@@ -17,7 +17,7 @@ from warnings import warn
 from .templates import HDFMapMSITemplate
 
 
-class hdfMap_msi_magneticfield(HDFMapMSITemplate):
+class HDFMapMSIMagneticField(HDFMapMSITemplate):
     """
     Mapping class for the 'Magnetic field' MSI diagnostic.
 

--- a/bapsflib/_hdf_mappers/msi/magneticfield.py
+++ b/bapsflib/_hdf_mappers/msi/magneticfield.py
@@ -14,10 +14,10 @@ import numpy as np
 from bapsflib.utils.errors import HDFMappingError
 from warnings import warn
 
-from .templates import hdfMap_msi_template
+from .templates import HDFMapMSITemplate
 
 
-class hdfMap_msi_magneticfield(hdfMap_msi_template):
+class hdfMap_msi_magneticfield(HDFMapMSITemplate):
     """
     Mapping class for the 'Magnetic field' MSI diagnostic.
 
@@ -36,7 +36,7 @@ class hdfMap_msi_magneticfield(hdfMap_msi_template):
         :type group: :class:`h5py.Group`
         """
         # initialize
-        hdfMap_msi_template.__init__(self, group)
+        HDFMapMSITemplate.__init__(self, group)
 
         # populate self.configs
         self._build_configs()

--- a/bapsflib/_hdf_mappers/msi/map_msi.py
+++ b/bapsflib/_hdf_mappers/msi/map_msi.py
@@ -14,7 +14,7 @@ from bapsflib.utils.errors import HDFMappingError
 
 from .discharge import HDFMapMSIDischarge
 from .gaspressure import HDFMapMSIGasPressure
-from .heater import hdfMap_msi_heater
+from .heater import HDFMapMSIHeater
 from .interferometerarray import hdfMap_msi_interarr
 from .magneticfield import hdfMap_msi_magneticfield
 
@@ -37,7 +37,7 @@ class HDFMapMSI(dict):
     _defined_mapping_classes = {
         'Discharge': HDFMapMSIDischarge,
         'Gas pressure': HDFMapMSIGasPressure,
-        'Heater': hdfMap_msi_heater,
+        'Heater': HDFMapMSIHeater,
         'Interferometer array': hdfMap_msi_interarr,
         'Magnetic field': hdfMap_msi_magneticfield
     }

--- a/bapsflib/_hdf_mappers/msi/map_msi.py
+++ b/bapsflib/_hdf_mappers/msi/map_msi.py
@@ -16,7 +16,7 @@ from .discharge import HDFMapMSIDischarge
 from .gaspressure import HDFMapMSIGasPressure
 from .heater import HDFMapMSIHeater
 from .interferometerarray import HDFMapMSIInterferometerArray
-from .magneticfield import hdfMap_msi_magneticfield
+from .magneticfield import HDFMapMSIMagneticField
 
 
 class HDFMapMSI(dict):
@@ -39,7 +39,7 @@ class HDFMapMSI(dict):
         'Gas pressure': HDFMapMSIGasPressure,
         'Heater': HDFMapMSIHeater,
         'Interferometer array': HDFMapMSIInterferometerArray,
-        'Magnetic field': hdfMap_msi_magneticfield
+        'Magnetic field': HDFMapMSIMagneticField
     }
     """
     Dictionary containing references to the defined (known) MSI

--- a/bapsflib/_hdf_mappers/msi/map_msi.py
+++ b/bapsflib/_hdf_mappers/msi/map_msi.py
@@ -11,12 +11,14 @@
 import h5py
 
 from bapsflib.utils.errors import HDFMappingError
+from typing import Dict
 
 from .discharge import HDFMapMSIDischarge
 from .gaspressure import HDFMapMSIGasPressure
 from .heater import HDFMapMSIHeater
 from .interferometerarray import HDFMapMSIInterferometerArray
 from .magneticfield import HDFMapMSIMagneticField
+from .templates import HDFMapMSITemplate
 
 
 class HDFMapMSI(dict):
@@ -77,7 +79,7 @@ class HDFMapMSI(dict):
         return tuple(self._defined_mapping_classes.keys())
 
     @property
-    def __build_dict(self) -> dict:
+    def __build_dict(self) -> Dict[str, HDFMapMSITemplate]:
         """
         Discovers the HDF5 MSI diagnostics and builds the dictionary
         containing the diagnostic mapping objects.  This is the

--- a/bapsflib/_hdf_mappers/msi/map_msi.py
+++ b/bapsflib/_hdf_mappers/msi/map_msi.py
@@ -13,7 +13,7 @@ import h5py
 from bapsflib.utils.errors import HDFMappingError
 
 from .discharge import HDFMapMSIDischarge
-from .gaspressure import hdfMap_msi_gaspressure
+from .gaspressure import HDFMapMSIGasPressure
 from .heater import hdfMap_msi_heater
 from .interferometerarray import hdfMap_msi_interarr
 from .magneticfield import hdfMap_msi_magneticfield
@@ -36,7 +36,7 @@ class HDFMapMSI(dict):
     """
     _defined_mapping_classes = {
         'Discharge': HDFMapMSIDischarge,
-        'Gas pressure': hdfMap_msi_gaspressure,
+        'Gas pressure': HDFMapMSIGasPressure,
         'Heater': hdfMap_msi_heater,
         'Interferometer array': hdfMap_msi_interarr,
         'Magnetic field': hdfMap_msi_magneticfield

--- a/bapsflib/_hdf_mappers/msi/map_msi.py
+++ b/bapsflib/_hdf_mappers/msi/map_msi.py
@@ -12,7 +12,7 @@ import h5py
 
 from bapsflib.utils.errors import HDFMappingError
 
-from .discharge import hdfMap_msi_discharge
+from .discharge import HDFMapMSIDischarge
 from .gaspressure import hdfMap_msi_gaspressure
 from .heater import hdfMap_msi_heater
 from .interferometerarray import hdfMap_msi_interarr
@@ -35,7 +35,7 @@ class HDFMapMSI(dict):
         ... msi_map = HDFMapMSI(f['MSI'])
     """
     _defined_mapping_classes = {
-        'Discharge': hdfMap_msi_discharge,
+        'Discharge': HDFMapMSIDischarge,
         'Gas pressure': hdfMap_msi_gaspressure,
         'Heater': hdfMap_msi_heater,
         'Interferometer array': hdfMap_msi_interarr,

--- a/bapsflib/_hdf_mappers/msi/map_msi.py
+++ b/bapsflib/_hdf_mappers/msi/map_msi.py
@@ -15,7 +15,7 @@ from bapsflib.utils.errors import HDFMappingError
 from .discharge import HDFMapMSIDischarge
 from .gaspressure import HDFMapMSIGasPressure
 from .heater import HDFMapMSIHeater
-from .interferometerarray import hdfMap_msi_interarr
+from .interferometerarray import HDFMapMSIInterferometerArray
 from .magneticfield import hdfMap_msi_magneticfield
 
 
@@ -38,7 +38,7 @@ class HDFMapMSI(dict):
         'Discharge': HDFMapMSIDischarge,
         'Gas pressure': HDFMapMSIGasPressure,
         'Heater': HDFMapMSIHeater,
-        'Interferometer array': hdfMap_msi_interarr,
+        'Interferometer array': HDFMapMSIInterferometerArray,
         'Magnetic field': hdfMap_msi_magneticfield
     }
     """

--- a/bapsflib/_hdf_mappers/msi/map_msi.py
+++ b/bapsflib/_hdf_mappers/msi/map_msi.py
@@ -19,7 +19,7 @@ from .interferometerarray import hdfMap_msi_interarr
 from .magneticfield import hdfMap_msi_magneticfield
 
 
-class hdfMap_msi(dict):
+class HDFMapMSI(dict):
     """
     A dictionary containing mapping objects for all the discovered
     MSI diagnostic HDF5 groups.  The dictionary keys are the MSI
@@ -28,11 +28,11 @@ class hdfMap_msi(dict):
     :Example:
 
         >>> from bapsflib import lapd
-        >>> from bapsflib._hdf_mappers import hdfMap_msi
+        >>> from bapsflib._hdf_mappers import HDFMapMSI
         >>> f = lapd.File('sample.hdf5')
         >>> # 'MSI' is the LaPD HDF5 group name for the group housing
         ... # MSI diagnostic groups
-        ... msi_map = hdfMap_msi(f['MSI'])
+        ... msi_map = HDFMapMSI(f['MSI'])
     """
     _defined_mapping_classes = {
         'Discharge': hdfMap_msi_discharge,

--- a/bapsflib/_hdf_mappers/msi/templates.py
+++ b/bapsflib/_hdf_mappers/msi/templates.py
@@ -175,7 +175,7 @@ class HDFMapMSITemplate(ABC):
         return self._info
 
     @property
-    def device_name(self):
+    def device_name(self) -> str:
         """Name of MSI diagnostic (device)"""
         return self._info['group name']
 

--- a/bapsflib/_hdf_mappers/msi/templates.py
+++ b/bapsflib/_hdf_mappers/msi/templates.py
@@ -14,7 +14,7 @@ import h5py
 from abc import (ABC, abstractmethod)
 
 
-class hdfMap_msi_template(ABC):
+class HDFMapMSITemplate(ABC):
     # noinspection PySingleQuotedDocstring
     '''
     Template class for all MSI diagnostic mapping classes to inherit
@@ -27,7 +27,7 @@ class hdfMap_msi_template(ABC):
             :param group: HDF5 group object
             """
             # initialize
-            hdfMap_msi_template.__init__(self, group)
+            HDFMapMSITemplate.__init__(self, group)
 
             # populate self.configs
             self._build_configs()

--- a/bapsflib/_hdf_mappers/msi/tests/common.py
+++ b/bapsflib/_hdf_mappers/msi/tests/common.py
@@ -15,7 +15,7 @@ import unittest as ut
 
 from bapsflib.lapd._hdf.tests import FauxHDFBuilder
 
-from ..templates import hdfMap_msi_template
+from ..templates import HDFMapMSITemplate
 
 
 class MSIDiagnosticTestCase(ut.TestCase):
@@ -95,7 +95,7 @@ class MSIDiagnosticTestCase(ut.TestCase):
         # interface objects can utilized the mapping.
         #
         # check mapping instance
-        self.assertIsInstance(_map, hdfMap_msi_template)
+        self.assertIsInstance(_map, HDFMapMSITemplate)
 
         # assert attribute existence
         self.assertTrue(hasattr(_map, 'info'))

--- a/bapsflib/_hdf_mappers/msi/tests/test_discharge.py
+++ b/bapsflib/_hdf_mappers/msi/tests/test_discharge.py
@@ -16,16 +16,16 @@ import unittest as ut
 
 from bapsflib.utils.errors import HDFMappingError
 
-from ..discharge import hdfMap_msi_discharge
+from ..discharge import HDFMapMSIDischarge
 from .common import MSIDiagnosticTestCase
 
 
 class TestDischarge(MSIDiagnosticTestCase):
-    """Test class for hdfMap_msi_discharge"""
+    """Test class for HDFMapMSIDischarge"""
     # define setup variables
     DEVICE_NAME = 'Discharge'
     DEVICE_PATH = '/MSI/Discharge'
-    MAP_CLASS = hdfMap_msi_discharge
+    MAP_CLASS = HDFMapMSIDischarge
 
     def setUp(self):
         super().setUp()

--- a/bapsflib/_hdf_mappers/msi/tests/test_gaspressure.py
+++ b/bapsflib/_hdf_mappers/msi/tests/test_gaspressure.py
@@ -16,16 +16,16 @@ import unittest as ut
 
 from bapsflib.utils.errors import HDFMappingError
 
-from ..gaspressure import hdfMap_msi_gaspressure
+from ..gaspressure import HDFMapMSIGasPressure
 from .common import MSIDiagnosticTestCase
 
 
 class TestGasPressure(MSIDiagnosticTestCase):
-    """Test class for hdfMap_msi_gaspressure"""
+    """Test class for HDFMapMSIGasPressure"""
     # define setup variables
     DEVICE_NAME = 'Gas pressure'
     DEVICE_PATH = '/MSI/Gas pressure'
-    MAP_CLASS = hdfMap_msi_gaspressure
+    MAP_CLASS = HDFMapMSIGasPressure
 
     def setUp(self):
         super().setUp()

--- a/bapsflib/_hdf_mappers/msi/tests/test_heater.py
+++ b/bapsflib/_hdf_mappers/msi/tests/test_heater.py
@@ -16,15 +16,15 @@ import unittest as ut
 
 from bapsflib.utils.errors import HDFMappingError
 
-from ..heater import hdfMap_msi_heater
+from ..heater import HDFMapMSIHeater
 from .common import MSIDiagnosticTestCase
 
 
 class TestHeater(MSIDiagnosticTestCase):
-    """Test class for hdfMap_msi_heater"""
+    """Test class for HDFMapMSIHeater"""
     DEVICE_NAME = 'Heater'
     DEVICE_PATH = '/MSI/Heater'
-    MAP_CLASS = hdfMap_msi_heater
+    MAP_CLASS = HDFMapMSIHeater
 
     def setUp(self):
         super().setUp()

--- a/bapsflib/_hdf_mappers/msi/tests/test_interferometerarray.py
+++ b/bapsflib/_hdf_mappers/msi/tests/test_interferometerarray.py
@@ -16,16 +16,16 @@ import unittest as ut
 
 from bapsflib.utils.errors import HDFMappingError
 
-from ..interferometerarray import hdfMap_msi_interarr
+from ..interferometerarray import HDFMapMSIInterferometerArray
 from .common import MSIDiagnosticTestCase
 
 
 class TestInterferometerArray(MSIDiagnosticTestCase):
-    """Test class for hdfMap_msi_interarr"""
+    """Test class for HDFMapMSIInterferometerArray"""
     # define setup variables
     DEVICE_NAME = 'Interferometer array'
     DEVICE_PATH = '/MSI/Interferometer array'
-    MAP_CLASS = hdfMap_msi_interarr
+    MAP_CLASS = HDFMapMSIInterferometerArray
 
     def setUp(self):
         super().setUp()

--- a/bapsflib/_hdf_mappers/msi/tests/test_magneticfield.py
+++ b/bapsflib/_hdf_mappers/msi/tests/test_magneticfield.py
@@ -16,16 +16,16 @@ import unittest as ut
 
 from bapsflib.utils.errors import HDFMappingError
 
-from ..magneticfield import hdfMap_msi_magneticfield
+from ..magneticfield import HDFMapMSIMagneticField
 from .common import MSIDiagnosticTestCase
 
 
 class TestMagneticField(MSIDiagnosticTestCase):
-    """Test class for hdfMap_msi_magneticfield"""
+    """Test class for HDFMapMSIMagneticField"""
     # define setup variables
     DEVICE_NAME = 'Magnetic field'
     DEVICE_PATH = '/MSI/Magnetic field'
-    MAP_CLASS = hdfMap_msi_magneticfield
+    MAP_CLASS = HDFMapMSIMagneticField
 
     def setUp(self):
         super().setUp()

--- a/bapsflib/_hdf_mappers/msi/tests/test_map_msi.py
+++ b/bapsflib/_hdf_mappers/msi/tests/test_map_msi.py
@@ -17,7 +17,7 @@ import unittest as ut
 from bapsflib.lapd._hdf.tests import FauxHDFBuilder
 
 from ..map_msi import hdfMap_msi
-from ..templates import hdfMap_msi_template
+from ..templates import HDFMapMSITemplate
 
 
 class TestHDFMapMSI(ut.TestCase):
@@ -156,7 +156,7 @@ class TestHDFMapMSI(ut.TestCase):
 
         # all dict items are a mapping class
         for val in msi_map.values():
-            self.assertIsInstance(val, hdfMap_msi_template)
+            self.assertIsInstance(val, HDFMapMSITemplate)
 
         # look for map attributes
         self.assertTrue(

--- a/bapsflib/_hdf_mappers/msi/tests/test_map_msi.py
+++ b/bapsflib/_hdf_mappers/msi/tests/test_map_msi.py
@@ -16,12 +16,12 @@ import unittest as ut
 
 from bapsflib.lapd._hdf.tests import FauxHDFBuilder
 
-from ..map_msi import hdfMap_msi
+from ..map_msi import HDFMapMSI
 from ..templates import HDFMapMSITemplate
 
 
 class TestHDFMapMSI(ut.TestCase):
-    """Test class for hdfMap_msi"""
+    """Test class for HDFMapMSI"""
     # What to test?
     # X  1. returned object is a dictionary
     # X  2. if input is not h5py.Group instance, then TypeError is
@@ -59,7 +59,7 @@ class TestHDFMapMSI(ut.TestCase):
     @staticmethod
     def map_msi(group):
         """Mapping function"""
-        return hdfMap_msi(group)
+        return HDFMapMSI(group)
 
     def test_not_h5py_group(self):
         """Test error if object to map is not h5py.Group"""
@@ -150,7 +150,7 @@ class TestHDFMapMSI(ut.TestCase):
         self.assertIn('Heater', _map)
         self.assertNotIn('Discharge', _map)
 
-    def assertBasics(self, msi_map: hdfMap_msi):
+    def assertBasics(self, msi_map: HDFMapMSI):
         # mapped object is a dictionary
         self.assertIsInstance(msi_map, dict)
 

--- a/bapsflib/lapd/_hdf/hdfmapper.py
+++ b/bapsflib/lapd/_hdf/hdfmapper.py
@@ -37,7 +37,7 @@ from bapsflib._hdf_mappers.controls.templates import (
 from bapsflib._hdf_mappers.map_digitizers import hdfMap_digitizers
 from bapsflib._hdf_mappers.map_digitizers.digi_template import \
     hdfMap_digi_template
-from bapsflib._hdf_mappers.msi import hdfMap_msi
+from bapsflib._hdf_mappers.msi import HDFMapMSI
 from bapsflib._hdf_mappers.msi.templates import HDFMapMSITemplate
 
 
@@ -57,7 +57,7 @@ class hdfMap(object):
 
     * :class:`~.controls.map_controls.HDFMapControls`.
     * :class:`~.map_digitizers.map_digis.hdfMap_digitizers`.
-    * :class:`~.msi.map_msi.hdfMap_msi`.
+    * :class:`~.msi.map_msi.HDFMapMSI`.
     """
     # MSI stuff
     _MSI_GNAME = 'MSI'
@@ -233,10 +233,10 @@ class hdfMap(object):
         """
         Attaches a dictionary (:attr:`__msi`) containing all MSI
         diagnostic mapping objects constructed by
-        :class:`~.msi.map_msi.hdfMap_msi`.
+        :class:`~.msi.map_msi.HDFMapMSI`.
         """
         if self.has_msi_group:
-            self.__msi = hdfMap_msi(self.__hdf_obj[self._MSI_GNAME])
+            self.__msi = HDFMapMSI(self.__hdf_obj[self._MSI_GNAME])
         else:
             self.__msi = {}
 

--- a/bapsflib/lapd/_hdf/hdfmapper.py
+++ b/bapsflib/lapd/_hdf/hdfmapper.py
@@ -38,13 +38,13 @@ from bapsflib._hdf_mappers.map_digitizers import hdfMap_digitizers
 from bapsflib._hdf_mappers.map_digitizers.digi_template import \
     hdfMap_digi_template
 from bapsflib._hdf_mappers.msi import hdfMap_msi
-from bapsflib._hdf_mappers.msi.templates import hdfMap_msi_template
+from bapsflib._hdf_mappers.msi.templates import HDFMapMSITemplate
 
 
 # define type aliases
 ControlMap = Union[HDFMapControlTemplate, HDFMapControlCLTemplate]
 DigiMap = hdfMap_digi_template
-MSIMap = hdfMap_msi_template
+MSIMap = HDFMapMSITemplate
 
 
 class hdfMap(object):

--- a/bapsflib/lapd/_hdf/hdfreadmsi.py
+++ b/bapsflib/lapd/_hdf/hdfreadmsi.py
@@ -27,7 +27,7 @@ class HDFReadMSI(np.ndarray):
        which is stored in the sub-fields of the :code:`'meta'` field
     #. recorded data arrays which get unique fields based on their
        mapping
-       :attr:`~bapsflib._hdf_mappers.msi.templates.hdfMap_msi_template.configs`
+       :attr:`~bapsflib._hdf_mappers.msi.templates.HDFMapMSITemplate.configs`
        attribute
 
     Data that is not shot number specific is stored in the :attr:`info`

--- a/docs/src/bapsflib._hdf_mappers.msi.discharge.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.discharge.rst
@@ -6,19 +6,8 @@ bapsflib\._hdf_mappers\.msi\.discharge
     :members:
     :undoc-members:
     :inherited-members:
-    :private-members:
 
-.. .. autoclass:: bapsflib.lapd.map_msi.discharge.HDFMapMSIDischarge
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    :inherited-members:
-    :exclude-members: configs
+    .. rubric:: Classes
 
-    .. .. py:attribute:: configs
-
-        .. Dictionary containing all the relevant mapping information to
-        translate the HDF5 data locations for the
-        :mod:`bapsflib.lapd` module.  For more detail see
-        :attr:`bapsflib.lapd.map_msi.msi_template.HDFMapMSITemplate.configs`
-        and :ref:`add_msi_mod`.
+    .. autosummary:: HDFMapMSIDischarge
+        :nosignatures:

--- a/docs/src/bapsflib._hdf_mappers.msi.discharge.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.discharge.rst
@@ -8,7 +8,7 @@ bapsflib\._hdf_mappers\.msi\.discharge
     :inherited-members:
     :private-members:
 
-.. .. autoclass:: bapsflib.lapd.map_msi.discharge.hdfMap_msi_discharge
+.. .. autoclass:: bapsflib.lapd.map_msi.discharge.HDFMapMSIDischarge
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/src/bapsflib._hdf_mappers.msi.discharge.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.discharge.rst
@@ -20,5 +20,5 @@ bapsflib\._hdf_mappers\.msi\.discharge
         .. Dictionary containing all the relevant mapping information to
         translate the HDF5 data locations for the
         :mod:`bapsflib.lapd` module.  For more detail see
-        :attr:`bapsflib.lapd.map_msi.msi_template.hdfMap_msi_template.configs`
+        :attr:`bapsflib.lapd.map_msi.msi_template.HDFMapMSITemplate.configs`
         and :ref:`add_msi_mod`.

--- a/docs/src/bapsflib._hdf_mappers.msi.gaspressure.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.gaspressure.rst
@@ -20,5 +20,5 @@ bapsflib\.\_hdf\_mappers\.msi\.gaspressure
         .. Dictionary containing all the relevant mapping information to
         translate the HDF5 data locations for the
         :mod:`bapsflib.lapd` module.  For more detail see
-        :attr:`bapsflib.lapd.map_msi.msi_template.hdfMap_msi_template.configs`
+        :attr:`bapsflib.lapd.map_msi.msi_template.HDFMapMSITemplate.configs`
         and :ref:`add_msi_mod`.

--- a/docs/src/bapsflib._hdf_mappers.msi.gaspressure.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.gaspressure.rst
@@ -8,7 +8,7 @@ bapsflib\.\_hdf\_mappers\.msi\.gaspressure
     :inherited-members:
     :private-members:
 
-.. .. autoclass:: bapsflib.lapd.map_msi.gaspressure.hdfMap_msi_gaspressure
+.. .. autoclass:: bapsflib.lapd.map_msi.gaspressure.HDFMapMSIGasPressure
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/src/bapsflib._hdf_mappers.msi.gaspressure.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.gaspressure.rst
@@ -6,19 +6,8 @@ bapsflib\.\_hdf\_mappers\.msi\.gaspressure
     :members:
     :undoc-members:
     :inherited-members:
-    :private-members:
 
-.. .. autoclass:: bapsflib.lapd.map_msi.gaspressure.HDFMapMSIGasPressure
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    :inherited-members:
-    :exclude-members: configs
+    .. rubric:: Classes
 
-    .. .. py:attribute:: configs
-
-        .. Dictionary containing all the relevant mapping information to
-        translate the HDF5 data locations for the
-        :mod:`bapsflib.lapd` module.  For more detail see
-        :attr:`bapsflib.lapd.map_msi.msi_template.HDFMapMSITemplate.configs`
-        and :ref:`add_msi_mod`.
+    .. autosummary:: HDFMapMSIGasPressure
+        :nosignatures:

--- a/docs/src/bapsflib._hdf_mappers.msi.heater.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.heater.rst
@@ -20,5 +20,5 @@ bapsflib\.\_hdf\_mappers\.msi\.heater
         .. Dictionary containing all the relevant mapping information to
         translate the HDF5 data locations for the
         :mod:`bapsflib.lapd` module.  For more detail see
-        :attr:`bapsflib.lapd.map_msi.msi_template.hdfMap_msi_template.configs`
+        :attr:`bapsflib.lapd.map_msi.msi_template.HDFMapMSITemplate.configs`
         and :ref:`add_msi_mod`.

--- a/docs/src/bapsflib._hdf_mappers.msi.heater.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.heater.rst
@@ -6,19 +6,8 @@ bapsflib\.\_hdf\_mappers\.msi\.heater
     :members:
     :undoc-members:
     :inherited-members:
-    :private-members:
 
-.. .. autoclass:: bapsflib.lapd.map_msi.heater.HDFMapMSIHeater
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    :inherited-members:
-    :exclude-members: configs
+    .. rubric:: Classes
 
-    .. .. py:attribute:: configs
-
-        .. Dictionary containing all the relevant mapping information to
-        translate the HDF5 data locations for the
-        :mod:`bapsflib.lapd` module.  For more detail see
-        :attr:`bapsflib.lapd.map_msi.msi_template.HDFMapMSITemplate.configs`
-        and :ref:`add_msi_mod`.
+    .. autosummary:: HDFMapMSIHeater
+        :nosignatures:

--- a/docs/src/bapsflib._hdf_mappers.msi.heater.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.heater.rst
@@ -8,7 +8,7 @@ bapsflib\.\_hdf\_mappers\.msi\.heater
     :inherited-members:
     :private-members:
 
-.. .. autoclass:: bapsflib.lapd.map_msi.heater.hdfMap_msi_heater
+.. .. autoclass:: bapsflib.lapd.map_msi.heater.HDFMapMSIHeater
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/src/bapsflib._hdf_mappers.msi.interferometerarray.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.interferometerarray.rst
@@ -8,7 +8,7 @@ bapsflib\._hdf_mappers\.msi\.interferometerarray
     :inherited-members:
     :private-members:
 
-.. .. autoclass:: bapsflib.lapd.map_msi.interferometerarray.hdfMap_msi_interarr
+.. .. autoclass:: bapsflib.lapd.map_msi.interferometerarray.HDFMapMSIInterferometerArray
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/src/bapsflib._hdf_mappers.msi.interferometerarray.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.interferometerarray.rst
@@ -20,5 +20,5 @@ bapsflib\._hdf_mappers\.msi\.interferometerarray
         .. Dictionary containing all the relevant mapping information to
         translate the HDF5 data locations for the
         :mod:`bapsflib.lapd` module.  For more detail see
-        :attr:`bapsflib.lapd.map_msi.msi_template.hdfMap_msi_template.configs`
+        :attr:`bapsflib.lapd.map_msi.msi_template.HDFMapMSITemplate.configs`
         and :ref:`add_msi_mod`.

--- a/docs/src/bapsflib._hdf_mappers.msi.interferometerarray.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.interferometerarray.rst
@@ -6,19 +6,8 @@ bapsflib\._hdf_mappers\.msi\.interferometerarray
     :members:
     :undoc-members:
     :inherited-members:
-    :private-members:
 
-.. .. autoclass:: bapsflib.lapd.map_msi.interferometerarray.HDFMapMSIInterferometerArray
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    :inherited-members:
-    :exclude-members: configs
+    .. rubric:: Classes
 
-    .. .. py:attribute:: configs
-
-        .. Dictionary containing all the relevant mapping information to
-        translate the HDF5 data locations for the
-        :mod:`bapsflib.lapd` module.  For more detail see
-        :attr:`bapsflib.lapd.map_msi.msi_template.HDFMapMSITemplate.configs`
-        and :ref:`add_msi_mod`.
+    .. autosummary:: HDFMapMSIInterferometerArray
+        :nosignatures:

--- a/docs/src/bapsflib._hdf_mappers.msi.magneticfield.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.magneticfield.rst
@@ -20,5 +20,5 @@ bapsflib\.\_hdf\_mappers\.msi\.magneticfield
         .. Dictionary containing all the relevant mapping information to
         translate the HDF5 data locations for the
         :mod:`bapsflib.lapd` module.  For more detail see
-        :attr:`bapsflib.lapd.map_msi.msi_template.hdfMap_msi_template.configs`
+        :attr:`bapsflib.lapd.map_msi.msi_template.HDFMapMSITemplate.configs`
         and :ref:`add_msi_mod`.

--- a/docs/src/bapsflib._hdf_mappers.msi.magneticfield.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.magneticfield.rst
@@ -6,19 +6,8 @@ bapsflib\.\_hdf\_mappers\.msi\.magneticfield
     :members:
     :undoc-members:
     :inherited-members:
-    :private-members:
 
-.. .. autoclass:: bapsflib.lapd.map_msi.magneticfield.HDFMapMSIMagneticField
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    :inherited-members:
-    :exclude-members: configs
+    .. rubric:: Classes
 
-    .. .. py:attribute:: configs
-
-        .. Dictionary containing all the relevant mapping information to
-        translate the HDF5 data locations for the
-        :mod:`bapsflib.lapd` module.  For more detail see
-        :attr:`bapsflib.lapd.map_msi.msi_template.HDFMapMSITemplate.configs`
-        and :ref:`add_msi_mod`.
+    .. autosummary:: HDFMapMSIMagneticField
+        :nosignatures:

--- a/docs/src/bapsflib._hdf_mappers.msi.magneticfield.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.magneticfield.rst
@@ -8,7 +8,7 @@ bapsflib\.\_hdf\_mappers\.msi\.magneticfield
     :inherited-members:
     :private-members:
 
-.. .. autoclass:: bapsflib.lapd.map_msi.magneticfield.hdfMap_msi_magneticfield
+.. .. autoclass:: bapsflib.lapd.map_msi.magneticfield.HDFMapMSIMagneticField
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/src/bapsflib._hdf_mappers.msi.map_msi.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.map_msi.rst
@@ -6,3 +6,8 @@ bapsflib\.\_hdf\_mappers\.msi\.map\_msi
     :undoc-members:
     :show-inheritance:
     :private-members:
+
+    .. rubric:: Classes
+
+    .. autosummary:: HDFMapMSI
+        :nosignatures:

--- a/docs/src/bapsflib._hdf_mappers.msi.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.rst
@@ -15,3 +15,15 @@ bapsflib\.\_hdf\_mappers\.msi
     bapsflib._hdf_mappers.msi.magneticfield
     bapsflib._hdf_mappers.msi.map_msi
     bapsflib._hdf_mappers.msi.templates
+
+.. rubric:: Classes
+
+.. autosummary::
+    :nosignatures:
+
+    HDFMapMSI
+
+.. autoclass:: HDFMapMSI
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/src/bapsflib._hdf_mappers.msi.templates.rst
+++ b/docs/src/bapsflib._hdf_mappers.msi.templates.rst
@@ -8,3 +8,10 @@ bapsflib\.\_hdf\_mappers\.msi\.templates
     :exclude-members: _abc_cache, _abc_negative_cache,
         _abc_negative_cache_version, _abc_registry
     :show-inheritance:
+
+    .. rubric:: Classes
+
+    .. autosummary::
+        :nosignatures:
+
+        HDFMapMSITemplate


### PR DESCRIPTION
All MSI mapping classes and modules are updated such that:

1. All mapping classes satisfy PEP8 CamelCase
1. All mapping classes have typing annotations
1. documentations source files (in '/docs/src/') have autosummary headers