### PR TITLE
'NI_XZ' control mapping module

### DIFF
--- a/bapsflib/_hdf/maps/controls/__init__.py
+++ b/bapsflib/_hdf/maps/controls/__init__.py
@@ -12,10 +12,11 @@
 Package of control device mapping classes and their constructor
 (:class:`~.map_controls.HDFMapControls`).
 """
-from . import (clparse, contype, map_controls, n5700ps, sixk,
+from . import (clparse, contype, map_controls, n5700ps, nixz, sixk,
                templates, waveform)
 from .contype import ConType
 from .map_controls import HDFMapControls
 
 __all__ = ['clparse', 'contype', 'ConType', 'HDFMapControls',
-           'map_controls', 'n5700ps', 'sixk', 'templates', 'waveform']
+           'map_controls', 'n5700ps', 'nixz', 'sixk', 'templates',
+           'waveform']

--- a/bapsflib/_hdf/maps/controls/map_controls.py
+++ b/bapsflib/_hdf/maps/controls/map_controls.py
@@ -14,6 +14,7 @@ from bapsflib.utils.errors import HDFMappingError
 from typing import (Dict, Tuple, Union)
 
 from .n5700ps import HDFMapControlN5700PS
+from .nixz import HDFMapControlNIXZ
 from .sixk import HDFMapControl6K
 from .templates import (HDFMapControlTemplate, HDFMapControlCLTemplate)
 from .waveform import HDFMapControlWaveform
@@ -40,9 +41,10 @@ class HDFMapControls(dict):
         <bapsflib._hdf.maps.controls.sixk.HDFMapControl6K>
     """
     _defined_mapping_classes = {
+        'N5700_PS': HDFMapControlN5700PS,
+        'NI_XZ': HDFMapControlNIXZ,
         '6K Compumotor': HDFMapControl6K,
         'Waveform': HDFMapControlWaveform,
-        'N5700_PS': HDFMapControlN5700PS,
     }
     """
     Dictionary containing references to the defined (known) control

--- a/bapsflib/_hdf/maps/controls/n5700ps.py
+++ b/bapsflib/_hdf/maps/controls/n5700ps.py
@@ -139,7 +139,7 @@ class HDFMapControlN5700PS(HDFMapControlCLTemplate):
                 'dset paths': self._configs[name]['dset paths'],
                 'dset field': ('Shot number',),
                 'shape': dset.dtype['Shot number'].shape,
-                'dtype': np.int32
+                'dtype': np.int32,
             }
 
             # ---- define 'state values'                            ----

--- a/bapsflib/_hdf/maps/controls/nixz.py
+++ b/bapsflib/_hdf/maps/controls/nixz.py
@@ -1,0 +1,199 @@
+# This file is part of the bapsflib package, a Python toolkit for the
+# BaPSF group at UCLA.
+#
+# http://plasma.physics.ucla.edu/
+#
+# Copyright 2017-2019 Erik T. Everson and contributors
+#
+# License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
+#   license terms and contributor agreement.
+#
+import h5py
+import numpy as np
+
+from bapsflib.utils.errors import HDFMappingError
+from warnings import warn
+
+from .contype import ConType
+from .templates import HDFMapControlTemplate
+
+
+class HDFMapControlNIXZ(HDFMapControlTemplate):
+    """
+    Mapping module for control device 'NI_XZ'.
+
+    Simple group structure looks like:
+
+    .. code-block:: none
+
+        +-- NI_XZ
+        |   +-- <motion list name 1>
+        |   |   +--
+        .
+        .
+        .
+        |   +-- <motion list name N>
+        |   |   +--
+        |   +-- Run time list
+    """
+    def __init__(self, group: h5py.Group):
+        """
+        :param group: the HDF5 control device group
+        """
+        HDFMapControlTemplate.__init__(self, group)
+
+        # define control type
+        self._info['contype'] = ConType.motion
+
+        # populate self.configs
+        self._build_configs()
+
+    def _build_configs(self):
+        """Build the :attr:`configs` dictionary"""
+        # Assumptions:
+        # 1. only one NI_XZ drive was ever built, so there will always
+        #    be only one configuration
+        #    - naming configuration 'config01'
+        # 2. there's only one dataset ever created 'Run time list'
+        # 3. there can be multiple motion lists defined
+        #    - each sub-group is a configuration for a different
+        #      motion list
+        #    - the name of the sub-group is the name of the motion list
+        #
+        # initialize configuration
+        cname = 'config01'
+        self.configs[cname] = {}
+
+        # check there are existing motion lists
+        if len(self.subgroup_names) == 0:
+            warn(self.info['group path']
+                 + ': no defining motion list groups exist')
+
+        # get dataset
+        try:
+            dset = self.group[self.construct_dataset_name()]
+        except KeyError:
+            why = ("Dataset '" + self.construct_dataset_name()
+                   + "' not found")
+            raise HDFMappingError(self.info['group path'], why=why)
+
+        # ---- define general config values                         ----
+        # none exist
+
+        # ---- define motion list values                            ----
+        self.configs[cname]['motion lists'] = {}
+
+        # get sub-group names (i.e. ml names)
+        _ml_names = []
+        for name in self.group:
+            if isinstance(self.group[name], h5py.Group):
+                _ml_names.append(name)
+
+        # a motion list group must have the attributes
+        # Nx, Nz, dx, dz, x0, z0
+        names_to_remove = []
+        for name in _ml_names:
+            if all(attr not in self.group[name].attrs
+                   for attr in ('Nx', 'Ny', 'dx', 'dz', 'x0', 'z0')):
+                names_to_remove.append(name)
+        if bool(names_to_remove):
+            for name in names_to_remove:
+                _ml_names.remove(name)
+
+        # warn if no motion lists exist
+        if not bool(_ml_names):
+            why = 'NI_XZ has no identifiable motion lists'
+            warn(why)
+
+        # gather ML config values
+        pairs = [
+            ('Nx', 'Nx'),
+            ('Nz', 'Nz'),
+            ('dx', 'dx'),
+            ('dz', 'dz'),
+            ('fan_XZ', 'fan_XZ'),
+            ('max_zdrive_steps', 'max_zdrive_steps'),
+            ('min_zdrive_steps', 'min_zdrive_steps'),
+            ('x0', 'x0'),
+            ('z0', 'z0'),
+            ('port', 'z_port'),
+        ]
+        for name in _ml_names:
+            # initialize ML dictionary
+            self.configs[cname]['motion lists'][name] = {}
+
+            # add ML values
+            for pair in pairs:
+                try:
+                    # get attribute value
+                    val = self.group[name].attrs[pair[1]]
+
+                    # condition value
+                    if np.issubdtype(type(val), np.bytes_):
+                        # - val is a np.bytes_ string
+                        val = val.decode('utf-8')
+                    if pair[1] == 'fan_XZ':
+                        # convert to boolean
+                        if val == 'TRUE':
+                            val = True
+                        else:
+                            val = False
+
+                    # assign val to configs
+                    self.configs[cname]['motion lists'][name][pair[0]] \
+                        = val
+                except KeyError:
+                    self.configs[cname]['motion lists'][name][pair[0]] \
+                        = None
+
+                    why = "Motion List attribute '" + pair[1] \
+                          + "' not found for ML group '" + name + "'"
+                    warn(why)
+
+        # ---- define 'dset paths'                                  ----
+        self.configs[cname]['dset paths'] = (dset.name,)
+
+        # ---- define 'shotnum'                                     ----
+        # check dset for 'Shot number' field
+        if 'Shot number' not in dset.dtype.names:
+            why = "Dataset '" + dset.name \
+                  + "' is missing 'Shot number' field"
+            raise HDFMappingError(self.info['group path'], why=why)
+
+        # initialize
+        self.configs[cname]['shotnum'] = {
+            'dset paths': self.configs[cname]['dset paths'],
+            'dset field': ('Shot number',),
+            'shape': dset.dtype['Shot number'].shape,
+            'dtype': np.int32,
+        }
+
+        # ---- define 'state values'                                ----
+        self._configs[cname]['state values'] = {
+            'xyz': {
+                'dset paths':
+                    self._configs[cname]['dset paths'],
+                'dset field': ('x', '', 'z'),
+                'shape': (3,),
+                'dtype': np.float64
+            },
+        }
+
+        # check dset for 'x' and 'z' fields
+        fx = 'x' not in dset.dtype.names
+        fz = 'z' not in dset.dtype.names
+        if fx and fz:
+            why = "Dataset '" + dset.name \
+                  + "' missing both field 'x' and 'z'"
+            raise HDFMappingError(self.info['group path'], why=why)
+        elif fx or fz:
+            missf = 'x' if fx else 'z'
+            why = " Dataset '" + dset.name \
+                  + "' missing field '" + missf + "'"
+            warn(why)
+
+    def construct_dataset_name(self, *args) -> str:
+        """
+        Constructs name of dataset containing control state value data.
+        """
+        return 'Run time list'

--- a/bapsflib/_hdf/maps/controls/tests/__init__.py
+++ b/bapsflib/_hdf/maps/controls/tests/__init__.py
@@ -8,6 +8,7 @@
 # License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
 #   license terms and contributor agreement.
 #
-from .fauxwaveform import FauxWaveform
-from .fauxsixk import FauxSixK
 from .fauxn5700ps import FauxN5700PS
+from .fauxnixz import FauxNIXZ
+from .fauxsixk import FauxSixK
+from .fauxwaveform import FauxWaveform

--- a/bapsflib/_hdf/maps/controls/tests/common.py
+++ b/bapsflib/_hdf/maps/controls/tests/common.py
@@ -43,9 +43,9 @@ class ControlTestCase(ut.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # skip tests if in MSIDiagnosticTestCase
+        # skip tests if in ControlTestCase
         if cls is ControlTestCase:
-            raise ut.SkipTest("In MSIDiagnosticTestCase, "
+            raise ut.SkipTest("In ControlTestCase, "
                               "skipping base tests")
         super().setUpClass()
 

--- a/bapsflib/_hdf/maps/controls/tests/fauxnixz.py
+++ b/bapsflib/_hdf/maps/controls/tests/fauxnixz.py
@@ -182,7 +182,7 @@ class FauxNIXZ(h5py.Group):
         self.create_dataset(dset_name, data=data)
 
         # add to configs
-        self._configs['config01']['dset name'] = dset_name
+        self.configs['config01']['dset name'] = dset_name
 
     def _add_motionlist_groups(self):
         """Add motion list groups"""
@@ -253,8 +253,8 @@ class FauxNIXZ(h5py.Group):
 
         # fill configs dict
         # there's one config and all ml's are in it
-        for config_name in self._configs:
-            self._configs[config_name]['motion lists'] = \
+        for config_name in self.configs:
+            self.configs[config_name]['motion lists'] = \
                 [self._ml[i]['name']
                  for i in range(self.knobs.n_motionlists)]
             # self._configs[config_name]['motion lists'] = \
@@ -291,7 +291,7 @@ class FauxNIXZ(h5py.Group):
         self._ml = []
 
         # re-initialize key dicts
-        self._configs = {'config01': {}}
+        self.configs = {'config01': {}}
 
         # add sub-groups
         self._add_motionlist_groups()

--- a/bapsflib/_hdf/maps/controls/tests/fauxnixz.py
+++ b/bapsflib/_hdf/maps/controls/tests/fauxnixz.py
@@ -1,0 +1,300 @@
+# This file is part of the bapsflib package, a Python toolkit for the
+# BaPSF group at UCLA.
+#
+# http://plasma.physics.ucla.edu/
+#
+# Copyright 2017-2018 Erik T. Everson and contributors
+#
+# License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
+#   license terms and contributor agreement.
+#
+import h5py
+import math
+import numpy as np
+import random
+
+from warnings import warn
+
+
+class FauxNIXZ(h5py.Group):
+    """
+    Creates a Faux 'NI_XZ' control group in the HDF5 file.
+    """
+
+    class Knobs(object):
+        """
+        A class that contains all the controls for specifying the
+        digitizer group structure.
+        """
+        def __init__(self, faux, n_motionlists, sn_size):
+            super().__init__()
+            self._faux = faux
+
+            # initialize knobs
+            self._n_configs = 1
+            self._n_probes = 1
+            self.n_motionlists = n_motionlists
+            self.sn_size = sn_size
+
+        @property
+        def n_configs(self):
+            """Number of NI_XZ configurations"""
+            # return self._faux.n_configs
+            return self._n_configs
+
+        @property
+        def n_motionlists(self):
+            """Number of motion lists"""
+            return self._n_motionlists
+
+        @n_motionlists.setter
+        def n_motionlists(self, val: int):
+            """Set number of motion lists"""
+            # check if self._n_motionlists has been defined
+            if hasattr(self, '_n_motionlists'):
+                old_val = self._n_motionlists
+            else:
+                old_val = 1
+
+            # condition val
+            if not isinstance(val, (int, np.integer)):
+                warn("Setting value must be an integer of >=1")
+                val = old_val
+            elif val < 1:
+                warn("Setting value must be an integer of >=1")
+                val = old_val
+
+            # only update if self._n_motionlists had been defined once
+            # prior
+            if hasattr(self, '_n_motionlists'):
+                self._n_motionlists = val
+                self._faux.populate()
+            else:
+                self._n_motionlists = val
+
+        @property
+        def n_probes(self):
+            """Number of controlled probes"""
+            # return self._faux.n_probes
+            return self._n_probes
+
+        @property
+        def sn_size(self):
+            """Shot number size"""
+            return self._sn_size
+
+        @sn_size.setter
+        def sn_size(self, val: int):
+            """Set shot number size"""
+            # check if self._sn_size has been defined
+            if hasattr(self, '_sn_size'):
+                old_val = self._sn_size
+            else:
+                old_val = 100
+
+            # condition val
+            if not isinstance(val, (int, np.integer)):
+                warn("Setting value must be an integer of >=1")
+                val = old_val
+            elif val < 1:
+                warn("Setting value must be an integer of >=1")
+                val = old_val
+
+            # only update if self._sn_size had been defined once prior
+            if hasattr(self, '_sn_size'):
+                self._sn_size = val
+                self._faux.populate()
+            else:
+                self._sn_size = val
+
+        def reset(self):
+            """Reset to defaults"""
+            self._n_configs = 1
+            self._n_probes = 1
+            self._n_motionlists = 1
+            self._sn_size = 100
+            self._faux.populate()
+
+    def __init__(self, id, n_motionlists=1, sn_size=100, **kwargs):
+        # ensure id is for a HDF5 group
+        if not isinstance(id, h5py.h5g.GroupID):
+            raise ValueError('{} is not a GroupID'.format(id))
+
+        # create control group
+        gid = h5py.h5g.create(id, b'NI_XZ')
+        h5py.Group.__init__(self, gid)
+
+        # store number on configurations
+        self._knobs = self.Knobs(self, n_motionlists, sn_size)
+
+        # set root attributes
+        self._set_xz_attrs()
+
+        # build control device sub-groups, datasets, and attributes
+        self.populate()
+
+    def _add_dataset(self):
+        """Create dataset"""
+        # create numpy array
+        dset_name = 'Run time list'
+        shape = (self.knobs.sn_size, )
+        dtype = np.dtype([
+            ('Shot number', np.int32),
+            ('Configuration name', np.bytes_, 120),
+            ('motion_index', np.int32),
+            ('z', np.float64),
+            ('r', np.float64),
+            ('x', np.float64),
+            ('theta', np.float64),
+        ])
+        data = np.ndarray(shape=shape, dtype=dtype)
+
+        # assign shot numbers
+        data['Shot number'] = \
+            np.arange(1, shape[0] + 1, 1,
+                      dtype=data.dtype['Shot number'].type)
+
+        # assign motion lists (aka 'Configuration name')
+        # assign motion_index
+        start = 0
+        for ml in self._ml:
+            # determine stop index
+            stop = start + ml['size']
+
+            # insert values
+            data['Configuration name'][start:stop:1] = ml['name']
+            data['motion_index'][start:stop:1] = \
+                np.arange(0, ml['size'], 1,
+                          dtype=data.dtype['motion_index'].type)
+
+            # move start index
+            start = stop
+
+        # fill position fields
+        # TODO: create a real fill, opposed to zeros
+        #
+        data['x'].fill(0.0)
+        data['z'].fill(1.0)
+        data['r'].fill(2.0)
+        data['theta'].fill(np.pi/10.0)
+
+        # create dataset
+        self.create_dataset(dset_name, data=data)
+
+        # add to configs
+        self._configs['config01']['dset name'] = dset_name
+
+    def _add_motionlist_groups(self):
+        """Add motion list groups"""
+        # determine possible data point arrangements for motion lists
+        # 1. find divisible numbers of sn_size
+        # 2. find (Nx, Nz) combos for each dataset
+        sn_size_for_ml = []
+        NN = []
+        if self.knobs.n_motionlists == 1:
+            # set shot number size per for each motion list
+            sn_size_for_ml.append(self.knobs.sn_size)
+        else:
+            # set shot number size per for each motion list
+            sn_per_ml = int(math.floor(
+                self.knobs.sn_size / self.knobs.n_motionlists))
+            sn_remainder = (self.knobs.sn_size
+                            - ((self.knobs.n_motionlists - 1)
+                               * sn_per_ml))
+            sn_size_for_ml.extend([sn_per_ml]
+                                  * (self.knobs.n_motionlists - 1))
+            sn_size_for_ml.append(sn_remainder)
+
+        # build NN of each motion list
+        for i in range(self.knobs.n_motionlists):
+            # find divisible numbers
+            sn_div = []
+            for j in range(sn_size_for_ml[i]):
+                if sn_size_for_ml[i] % (j + 1) == 0:
+                    sn_div.append(j + 1)
+
+            # build (Nx, Nz)
+            sn_div_index = random.randint(0, len(sn_div) - 1)
+            Nx = sn_div[sn_div_index]
+            Nz = int(sn_size_for_ml[i] / Nx)
+            NN.append((Nx, Nz))
+
+        # add motionlist sub-groups
+        # - define motionlist names
+        # - create motionlist group
+        # - define motionlist group attributes
+        for i in range(self.knobs.n_motionlists):
+            # define motionlist name
+            ml_name = 'ml-{:04}'.format(i + 1)
+            self._ml.append({'name': ml_name,
+                             'size': sn_size_for_ml[i]})
+            # self._motionlist_names.append(ml_name)
+
+            # create motionlist group
+            ml_gname = ml_name
+            self.create_group(ml_gname)
+
+            # set motionlist attributes
+            self[ml_gname].attrs.update({
+                'z_port': np.float64(35.0),
+                'x0': np.float64(0.0),
+                'Nx': np.float64(NN[i][0]),
+                'dx': np.float64(0.5),
+                'fan_XZ':
+                    np.bytes_('FALSE') if bool(i % 2)
+                    else np.bytes_('TRUE'),
+                'z0': np.float64(0.0),
+                'Nz': np.float64(NN[i][1]),
+                'dz': np.float64(0.5),
+                'min_zdrive_steps': np.float64(16491),
+                'max_zdrive_steps': np.float64(-22833),
+                'probe_name': np.bytes_('probe1'),
+            })
+
+        # fill configs dict
+        # there's one config and all ml's are in it
+        for config_name in self._configs:
+            self._configs[config_name]['motion lists'] = \
+                [self._ml[i]['name']
+                 for i in range(self.knobs.n_motionlists)]
+            # self._configs[config_name]['motion lists'] = \
+            #     self._motionlist_names
+
+    def _set_xz_attrs(self):
+        """Set the 'NI_XZ' group attributes"""
+        self.attrs.update({
+            'Device name': np.bytes_('NI_XZ'),
+            'Type': np.bytes_('Experimental control'),
+            'Description': np.bytes_(
+                'The NI_XZ device provides accurate probe position '
+                'control on the central horizontal plane on LaPD.\n'
+                'Uses  National Instruments motion hardware.'),
+            'Module IP address': np.bytes_('192.168.7.32'),
+            'Module VI path': np.bytes_('Modules\\NI_XZ\\NI_XZ.vi'),
+            'Created data': np.bytes_('1/28/2015 3:03:58 PM'),
+        })
+
+    @property
+    def knobs(self):
+        """Knobs for controlling structure of device group"""
+        return self._knobs
+
+    def populate(self):
+        """
+        Updates the control group structure (Groups, Datasets, and
+        Attributes)
+        """
+        # clear group before rebuild
+        self.clear()
+
+        # re-initialize key lists
+        self._ml = []
+
+        # re-initialize key dicts
+        self._configs = {'config01': {}}
+
+        # add sub-groups
+        self._add_motionlist_groups()
+
+        # add datasets
+        self._add_dataset()

--- a/bapsflib/_hdf/maps/controls/tests/fauxsixk.py
+++ b/bapsflib/_hdf/maps/controls/tests/fauxsixk.py
@@ -9,10 +9,10 @@
 #   license terms and contributor agreement.
 #
 import h5py
-import random
 import math
 import numpy as np
 import platform
+import random
 
 from datetime import datetime as dt
 from warnings import warn

--- a/bapsflib/_hdf/maps/controls/tests/test_nixz.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_nixz.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# This file is part of the bapsflib package, a Python toolkit for the
+# BaPSF group at UCLA.
+#
+# http://plasma.physics.ucla.edu/
+#
+# Copyright 2017-2019 Erik T. Everson and contributors
+#
+# License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
+#   license terms and contributor agreement.
+#
+import h5py
+import unittest as ut
+
+from bapsflib.utils.errors import HDFMappingError
+
+from .common import ControlTestCase
+from .. import ConType
+from ..nixz import HDFMapControlNIXZ
+
+
+class TestNIXZ(ControlTestCase):
+    """Test class for HDFMapControlNIXZ"""
+
+    # define setup variables
+    DEVICE_NAME = 'NI_XZ'
+    DEVICE_PATH = 'Raw data + config/NI_XZ'
+    MAP_CLASS = HDFMapControlNIXZ
+
+    def setUp(self):
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test_contype(self):
+        self.assertEqual(self.map.info['contype'], ConType.motion)
+
+    def test_map_failures(self):
+        """Test conditions that result in unsuccessful mappings."""
+        # any failed build must throw a HDFMappingError
+        #
+        # 1. 'Run time list' is missing
+        # 2. dataset is missing 'Shot number' field
+        # 3. dataset is missing 'x' and 'z' fields
+        #
+        # make a default/clean 'NI_XZ' module
+        self.mod.knobs.reset()
+
+        # dataset 'Run time list' missing                            (1)
+        # - rename 'Run time list' dataset
+        self.mod.move('Run time list', 'NIXZ data')
+        with self.assertRaises(HDFMappingError):
+            _map = self.map
+        self.mod.move('NIXZ data', 'Run time list')
+
+        # dataset missing 'Shot number' field                        (2)
+        self.mod.move('Run time list', 'NIXZ data')
+        odata = self.mod['NIXZ data'][...]
+        fields = list(odata.dtype.names)
+        fields.remove('Shot number')
+        data = odata[fields]
+        self.mod.create_dataset('Run time list', data=data)
+        with self.assertRaises(HDFMappingError):
+            _map = self.map
+        del self.mod['Run time list']
+        self.mod.move('NIXZ data', 'Run time list')
+
+        # dataset missing 'x' and 'z' fields                         (3)
+        self.mod.move('Run time list', 'NIXZ data')
+        odata = self.mod['NIXZ data'][...]
+        fields = list(odata.dtype.names)
+        fields.remove('x')
+        fields.remove('z')
+        data = odata[fields]
+        self.mod.create_dataset('Run time list', data=data)
+        with self.assertRaises(HDFMappingError):
+            _map = self.map
+        del self.mod['Run time list']
+        self.mod.move('NIXZ data', 'Run time list')
+
+    def test_map_warnings(self):
+        """Test conditions that issue a UserWarning"""
+        # Warnings relate to unexpected behavior that does not affect
+        # reading of data from the HDF5 file
+        #
+        # 1. No motion list group is found
+        # 2. motion list group is missing an attribute
+        # 3. dataset 'Run time list' is missing on of 'x' or 'z' fields
+        #
+        # make a default/clean 'NI_XZ' module
+        self.mod.knobs.reset()
+
+        # no motion list group is found                              (1)
+        del self.mod['ml-0001']
+        with self.assertWarns(UserWarning):
+            _map = self.map
+            self.assertNIXZDetails(_map, self.dgroup)
+        self.mod.knobs.reset()
+
+        # motion list group is missing an attribute                  (2)
+        del self.mod['ml-0001'].attrs['Nx']
+        with self.assertWarns(UserWarning):
+            _map = self.map
+            self.assertNIXZDetails(_map, self.dgroup)
+        self.mod.knobs.reset()
+
+        # dataset 'Run time list' is missing one of 'x' or 'z'       (3)
+        # fields
+        self.mod.move('Run time list', 'NIXZ data')
+        odata = self.mod['NIXZ data'][...]
+        fields = list(odata.dtype.names)
+        fields.remove('x')
+        data = odata[fields]
+        self.mod.create_dataset('Run time list', data=data)
+        del self.mod['NIXZ data']
+        with self.assertWarns(UserWarning):
+            _map = self.map
+            self.assertNIXZDetails(_map, self.dgroup)
+        self.mod.knobs.reset()
+
+    def test_misc(self):
+        """Test miscellaneous behavior"""
+        # 1. there are 2 motion list groups
+        # 2. motion list group is missing all key attributes
+        #
+        # make a default/clean 'NI_XZ' module
+        self.mod.knobs.reset()
+
+        # there are 2 motion list groups                             (1)
+        self.mod.knobs.n_motionlists = 2
+        _map = self.map
+        self.assertNIXZDetails(_map, self.dgroup)
+        for name in self.mod.configs['config01']['motion lists']:
+            self.assertIn(name,
+                          _map.configs['config01']['motion lists'])
+        self.mod.knobs.reset()
+
+        # motion list group is missing all key attributes            (2)
+        # key attributes: Nx, Nz, dx, dz, x0, z0
+        self.mod.knobs.n_motionlists = 2
+        for key in ('Nx', 'Nz', 'dx', 'dz', 'x0', 'z0'):
+            del self.mod['ml-0001'].attrs[key]
+        _map = self.map
+        self.assertNIXZDetails(_map, self.dgroup)
+        self.assertNotIn('ml-0001',
+                         _map.configs['config01']['motion lists'])
+        self.assertIn('ml-0002',
+                      _map.configs['config01']['motion lists'])
+
+    def assertNIXZDetails(self,
+                          _map: HDFMapControlNIXZ,
+                          _group: h5py.Group):
+        """Assert details of the 'NI_XZ' mapping."""
+        # confirm basics
+        self.assertControlMapBasics(_map, _group)
+
+        # check dataset names
+        self.assertEqual(_map.construct_dataset_name(), 'Run time list')
+
+        # no command list
+        self.assertFalse(_map.has_command_list)
+
+        # there only ever one configuration
+        self.assertEqual(len(_map.configs), 1)
+        self.assertEqual(list(_map.configs), ['config01'])
+        self.assertTrue(_map.one_config_per_dset)
+
+        # test general item sin configs
+        self.assertNIXZConfigItems(_map)
+
+    def assertNIXZConfigItems(self, _map):
+        """
+        Test structure of the general, polymorphic elements of the
+        `configs` mapping dictionary
+        """
+        config = _map.configs['config01']
+        self.assertIn('motion lists', config)
+        self.assertIsInstance(config['motion lists'], dict)
+
+
+if __name__ == '__main__':
+    ut.main()

--- a/bapsflib/_hdf/maps/tests/fauxhdfbuilder.py
+++ b/bapsflib/_hdf/maps/tests/fauxhdfbuilder.py
@@ -14,9 +14,10 @@ import os
 import tempfile
 
 from ..controls.tests import (
-    FauxWaveform,
-    FauxSixK,
     FauxN5700PS,
+    FauxNIXZ,
+    FauxSixK,
+    FauxWaveform,
 )
 from ..digitizers.tests import (
     FauxSIS3301,
@@ -48,9 +49,10 @@ class FauxHDFBuilder(h5py.File):
         'SIS crate': FauxSISCrate,
     }
     _KNOWN_CONTROLS = {
-        'Waveform': FauxWaveform,
         '6K Compumotor': FauxSixK,
         'N5700_PS': FauxN5700PS,
+        'NI_XZ': FauxNIXZ,
+        'Waveform': FauxWaveform,
     }
     _KNOWN_MODULES = _KNOWN_CONTROLS.copy()  # type: Dict[Any]
     _KNOWN_MODULES.update(_KNOWN_MSI)

--- a/bapsflib/_hdf/maps/tests/fauxhdfbuilder.py
+++ b/bapsflib/_hdf/maps/tests/fauxhdfbuilder.py
@@ -253,3 +253,14 @@ class FauxHDFBuilder(h5py.File):
         modules = list(self._modules.keys())
         for mod in modules:
             self.remove_module(mod)
+
+    def reset(self):
+        """
+        Restore file such that only empty version of the 'MSI' and
+        'Raw data + config' group exist.
+        """
+        self.remove_all_modules()
+        for name in self['MSI']:
+            del self['MSI/' + name]
+        for name in self['Raw data + config']:
+            del self['Raw data + config/' + name]

--- a/bapsflib/_hdf/utils/hdfreadcontrol.py
+++ b/bapsflib/_hdf/utils/hdfreadcontrol.py
@@ -451,13 +451,6 @@ class HDFReadControl(np.ndarray):
                             ii = np.s_[sni_not]
 
                         # NaN fill
-                        #if np.issubdtype(dtype, np.integer):
-                        #    # any integer, signed or not
-                        #    fill = 0 \
-                        #        if isinstance(dtype,
-                        #                      np.unsignedinteger) \
-                        #        else -99999
-                        #    data[nf_name][ii] = fill
                         if np.issubdtype(dtype, np.signedinteger):
                             data[nf_name][ii] = -99999
                         elif np.issubdtype(dtype, np.unsignedinteger):

--- a/bapsflib/_hdf/utils/hdfreadcontrol.py
+++ b/bapsflib/_hdf/utils/hdfreadcontrol.py
@@ -395,13 +395,17 @@ class HDFReadControl(np.ndarray):
                             ii = np.s_[sni_not]
 
                         # NaN fill
-                        if np.issubdtype(dtype, np.integer):
-                            # any integer, signed or not
-                            fill = 0 \
-                                if isinstance(dtype,
-                                              np.unsignedinteger) \
-                                else -99999
-                            data[nf_name][ii] = fill
+                        #if np.issubdtype(dtype, np.integer):
+                        #    # any integer, signed or not
+                        #    fill = 0 \
+                        #        if isinstance(dtype,
+                        #                      np.unsignedinteger) \
+                        #        else -99999
+                        #    data[nf_name][ii] = fill
+                        if np.issubdtype(dtype, np.signedinteger):
+                            data[nf_name][ii] = -99999
+                        elif np.issubdtype(dtype, np.unsignedinteger):
+                            data[nf_name][ii] = 0
                         elif np.issubdtype(dtype, np.floating):
                             # any float type
                             data[nf_name][ii] = np.nan

--- a/bapsflib/_hdf/utils/hdfreadcontrol.py
+++ b/bapsflib/_hdf/utils/hdfreadcontrol.py
@@ -416,7 +416,7 @@ class HDFReadControl(np.ndarray):
                                     # string, unicode, void
                                     # np.zero satisfies this
                                     pass
-                                else:
+                                else:  # pragma: no cover
                                     # no real NaN concept exists
                                     # - this shouldn't happen though
                                     warn('dtype ({}) of '.format(dtype)

--- a/bapsflib/_hdf/utils/tests/__init__.py
+++ b/bapsflib/_hdf/utils/tests/__init__.py
@@ -27,7 +27,7 @@ class TestBase(ut.TestCase):
         cls.f = FauxHDFBuilder()
 
     def tearDown(self):
-        self.f.remove_all_modules()
+        self.f.reset()
 
     @classmethod
     def tearDownClass(cls):

--- a/bapsflib/_hdf/utils/tests/test_hdfoverview.py
+++ b/bapsflib/_hdf/utils/tests/test_hdfoverview.py
@@ -39,7 +39,6 @@ class TestHDFOverview(TestBase):
 
     def tearDown(self):
         super().tearDown()
-        del self.f['Raw data + config/Unknown']
 
     @property
     def overview(self):

--- a/bapsflib/_hdf/utils/tests/test_hdfreadcontrol.py
+++ b/bapsflib/_hdf/utils/tests/test_hdfreadcontrol.py
@@ -106,12 +106,14 @@ class TestHDFReadControl(TestBase):
         # -- Define "Sample Control" in HDF5 file                   ----
         data = np.empty(10,
                         dtype=[('Shot number', np.uint32),
+                               ('index', np.int32),
                                ('bits', np.uint32),
                                ('signal', np.float32),
                                ('command', np.bytes_, 10),
                                ('valid', np.bool)])
         data['Shot number'] = np.arange(1, 11, 1, dtype=np.uint32)
-        data['bits'] = np.arange(-11, -21, -1, dtype=np.int32)
+        data['index'] = np.arange(-11, -21, -1, dtype=np.int32)
+        data['bits'] = np.arange(21, 31, 1, dtype=np.uint32)
         data['signal'] = np.arange(-5.0, 9.0, 1.5, dtype=np.float32)
         for ii in range(data.size):
             data['command'][ii] = \
@@ -146,11 +148,17 @@ class TestHDFReadControl(TestBase):
                         'dtype': np.uint32,
                     },
                     'state values': {
+                        'index': {
+                            'dset paths': dset_paths,
+                            'dset field': ('index',),
+                            'shape': (),
+                            'dtype': np.int32,
+                        },
                         'bits': {
                             'dset paths': dset_paths,
                             'dset field': ('bits',),
                             'shape': (),
-                            'dtype': np.int32,
+                            'dtype': np.uint32,
                         },
                         'signal': {
                             'dset paths': dset_paths,
@@ -849,10 +857,11 @@ class TestHDFReadControl(TestBase):
                 dtype = cdata.dtype[field].base
 
                 # assert "NaN" fills
-                if np.issubdtype(dtype, np.integer):
-                    fill = 0 if isinstance(dtype, np.unsignedinteger) \
-                        else -99999
-                    cd_nan = np.where(cdata[field] == fill,
+                if np.issubdtype(dtype, np.signedinteger):
+                    cd_nan = np.where(cdata[field] == -99999,
+                                      True, False)
+                elif np.issubdtype(dtype, np.unsignedinteger):
+                    cd_nan = np.where(cdata[field] == 0,
                                       True, False)
                 elif np.issubdtype(dtype, np.floating):
                     cd_nan = np.isnan(cdata[field])


### PR DESCRIPTION
Adds ability to interface with the 'NI_XZ' control device.  The 'NI_XZ' control device is used to moving a probe in the XZ-plane of the LaPD.

This merge includes:

1.  Addition of the `HDFMapControlNIXZ` class for mapping the 'NI_XZ' control device
    * 100% coverage of tests
1. `HDFReadControl` needed to be updated such that the population of the`'xyz'` field does not fail, since the 'NI_XZ' dataset does not store y-coordinate values
    * Now, when defining the `configs` mapping dictionary, if the dataset field is defined as a null string `''`, then `HDFReadControl` assumes that the corresponding numpy field is supposed to be filled with zeros.
    * For example, if
        ```
        configs[cname]['state values']['xyz'] = {
            'dset paths': 'path/to/dataset',
            'dset field': ('x', '', 'z'),
            'shape': (3,),
            'dtype': np.float64,
         }
        ```
        then the y-coordinate, or `data['xyz'][...,1]`, will be filled with zeros.
    * This will work for any numpy field that has multiple dataset fields mapped to it.
    * Test are updated to maintain 100% coverage