### PR TITLE
Add AppVeyor Support for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 [![Documentation Status](https://readthedocs.org/projects/bapsflib/badge/)](https://bapsflib.readthedocs.io/en/latest)
 [![Build Status](https://img.shields.io/travis/BaPSF/bapsflib/master.svg?label=Travis%20CI)](https://travis-ci.org/BaPSF/bapsflib)
+[![Build status](https://ci.appveyor.com/api/projects/status/kuia1r8iiqwiu2gg/branch/master?svg=true)](https://ci.appveyor.com/project/rocco8773/bapsflib/branch/master)
 [![codecov](https://codecov.io/gh/BaPSF/bapsflib/branch/master/graph/badge.svg)](https://codecov.io/gh/BaPSF/bapsflib/branch/master)
 
 [![h5py](https://img.shields.io/badge/powered%20by-h5py-%235e9ffa.svg)](https://www.h5py.org/)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,11 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Python35"
-    #- PYTHON: "C:\\Python36"
-    #- PYTHON: "C:\\Python37"
-    #- PYTHON: "C:\\Python35-x64"
-    #- PYTHON: "C:\\Python36-x64"
-    #- PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python37"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37-x64"
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,11 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Python35"
-    - PYTHON: "C:\\Python35-x64"
-    - PYTHON: "C:\\Python36"
-    - PYTHON: "C:\\Python36-x64"
+    #- PYTHON: "C:\\Python36"
+    #- PYTHON: "C:\\Python37"
+    #- PYTHON: "C:\\Python35-x64"
+    #- PYTHON: "C:\\Python36-x64"
+    #- PYTHON: "C:\\Python37-x64"
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+# AppVeyor.com is a Continuous Integration service to build and run
+# tests under Windows
+environment:
+
+  matrix:
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python36-x64"
+
+install:
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
+
+# Not a .NET project, package is built in the install step instead
+build: off
+
+test_script:
+  - "%PYTHON%\\python.exe -m unittest discover"

--- a/bapsflib/_hdf/maps/tests/fauxhdfbuilder.py
+++ b/bapsflib/_hdf/maps/tests/fauxhdfbuilder.py
@@ -167,10 +167,7 @@ class FauxHDFBuilder(h5py.File):
         if isinstance(self.tempdir, tempfile.TemporaryDirectory):
             if platform.system() == 'Windows':
                 # tempfile is already closed, need to remove file
-                # print(self.tempfile.closed)
                 os.remove(_path)
-                print("File '{}'exists ".format(_path)
-                      + "{}".format(os.path.isfile(_path)))
             else:
                 self.tempfile.close()
             self.tempdir.cleanup()

--- a/bapsflib/_hdf/maps/tests/fauxhdfbuilder.py
+++ b/bapsflib/_hdf/maps/tests/fauxhdfbuilder.py
@@ -167,8 +167,10 @@ class FauxHDFBuilder(h5py.File):
         if isinstance(self.tempdir, tempfile.TemporaryDirectory):
             if platform.system() == 'Windows':
                 # tempfile is already closed, need to remove file
-                print(self.tempfile.closed)
-                # os.remove(_path)
+                # print(self.tempfile.closed)
+                os.remove(_path)
+                print("File '{}'exists ".format(_path)
+                      + "{}".format(os.path.isfile(_path)))
             else:
                 self.tempfile.close()
             self.tempdir.cleanup()

--- a/bapsflib/_hdf/maps/tests/fauxhdfbuilder.py
+++ b/bapsflib/_hdf/maps/tests/fauxhdfbuilder.py
@@ -11,6 +11,7 @@
 import h5py
 import inspect
 import os
+import platform
 import tempfile
 
 from ..controls.tests import (
@@ -66,19 +67,32 @@ class FauxHDFBuilder(h5py.File):
         """
         # define file name, directory, and path
         if name is None:
+            # define NamedTemporaryFile delete
+            # - on a Unix platform the file can be opened multiple times
+            # - on a Windows platform it can only be opened once
+            #   * thus, delete=False needs to be set so the file
+            #     persists for play
+            delete = False if platform.system() == 'Windows' else True
+
             # create temporary directory and file
             self._tempdir = \
                 tempfile.TemporaryDirectory(prefix='hdf-test_')
             self._tempfile = \
-                tempfile.NamedTemporaryFile(suffix='.hdf5',
-                                            dir=self.tempdir.name,
-                                            delete=False)
-            self._path = self.tempfile.name
+                tempfile.NamedTemporaryFile(
+                    suffix='.hdf5',
+                    dir=os.path.abspath(self.tempdir.name),
+                    delete=delete)
+            self._path = os.path.abspath(self.tempfile.name)
+
+            if platform.system() == 'Windows':
+                # close the file so h5py can access it on a Windows
+                # platform
+                self._tempfile.close()
         else:
             # use specified directory and file
             self._tempdir = None
             self._tempfile = None
-            self._path = name
+            self._path = os.path.abspath(name)
 
         # initialize
         h5py.File.__init__(self, self.path, 'w')
@@ -141,19 +155,30 @@ class FauxHDFBuilder(h5py.File):
         """Path to HDF5 file"""
         return self._path
 
+    def close(self):
+        """
+        Close the HDF5 file and remove temporary files/directories if
+        the exist.
+        """
+        _path = os.path.abspath(self.filename)
+        super().close()
+
+        # cleanup temporary directory and file
+        if isinstance(self.tempdir, tempfile.TemporaryDirectory):
+            if platform.system() == 'Windows':
+                # tempfile is already closed, need to remove file
+                print(self.tempfile.closed)
+                # os.remove(_path)
+            else:
+                self.tempfile.close()
+            self.tempdir.cleanup()
+
     def cleanup(self):
         """
         Close the HDF5 file and cleanup any temporary directories and
         files.
         """
-        # close HDF5 file object
         self.close()
-
-        # cleanup temporary direcotry and file
-        if isinstance(self.tempdir, tempfile.TemporaryDirectory):
-            self.tempfile.close()
-            os.unlink(self.tempfile.name)
-            self.tempdir.cleanup()
 
     def valid_modules(self):
         """

--- a/bapsflib/_hdf/utils/tests/__init__.py
+++ b/bapsflib/_hdf/utils/tests/__init__.py
@@ -11,8 +11,34 @@
 import unittest as ut
 
 from bapsflib._hdf.maps import FauxHDFBuilder
+from functools import wraps
 
 from ..file import File
+
+
+def with_bf(func):
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        with File(self.f.filename,
+                  control_path='Raw data + config',
+                  digitizer_path='Raw data + config',
+                  msi_path='MSI') as bf:
+            return func(self, bf, *args, **kwargs)
+    return wrapper
+
+'''
+def with_bf(filename):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            with File(filename,
+                      control_path='Raw data + config',
+                      digitizer_path='Raw data + config',
+                      msi_path='MSI') as bf:
+                func(bf, *args, **kwargs)
+        return wrapper
+    return decorator
+'''
 
 
 class TestBase(ut.TestCase):

--- a/bapsflib/_hdf/utils/tests/__init__.py
+++ b/bapsflib/_hdf/utils/tests/__init__.py
@@ -17,6 +17,11 @@ from ..file import File
 
 
 def with_bf(func):
+    """
+    Context decorator for managing the opening and closing BaPSF HDF5
+    Files :class:`bapsflib._hdf.utils.file.File`.  Intended for use on
+    test methods.
+    """
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         with File(self.f.filename,
@@ -25,20 +30,6 @@ def with_bf(func):
                   msi_path='MSI') as bf:
             return func(self, bf, *args, **kwargs)
     return wrapper
-
-'''
-def with_bf(filename):
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            with File(filename,
-                      control_path='Raw data + config',
-                      digitizer_path='Raw data + config',
-                      msi_path='MSI') as bf:
-                func(bf, *args, **kwargs)
-        return wrapper
-    return decorator
-'''
 
 
 class TestBase(ut.TestCase):
@@ -60,9 +51,3 @@ class TestBase(ut.TestCase):
         # cleanup and close HDF5 file
         super().tearDownClass()
         cls.f.cleanup()
-
-    @property
-    def bf(self) -> File:
-        """Opened BaPSF HDF5 File instance."""
-        return File(self.f.filename, control_path='Raw data + config',
-                    digitizer_path='Raw data + config', msi_path='MSI')

--- a/bapsflib/_hdf/utils/tests/test_hdfoverview.py
+++ b/bapsflib/_hdf/utils/tests/test_hdfoverview.py
@@ -18,7 +18,8 @@ import unittest as ut
 from bapsflib._hdf.maps import HDFMap
 from unittest import mock
 
-from . import TestBase
+from . import (TestBase, with_bf)
+from ..file import File
 from ..hdfoverview import HDFOverview
 
 
@@ -40,10 +41,6 @@ class TestHDFOverview(TestBase):
     def tearDown(self):
         super().tearDown()
 
-    @property
-    def overview(self):
-        return self.create_overview(self.bf)
-
     @staticmethod
     def create_overview(file):
         return HDFOverview(file)
@@ -53,9 +50,9 @@ class TestHDFOverview(TestBase):
         with self.assertRaises(ValueError):
             self.create_overview(None)
 
-    def test_overview_basics(self):
-        _bf = self.bf
-        _overview = self.overview
+    @with_bf
+    def test_overview_basics(self, _bf: File):
+        _overview = self.create_overview(_bf)
 
         # -- attribute existence                                    ----
         self.assertTrue(hasattr(_overview, 'control_discovery'))
@@ -74,12 +71,12 @@ class TestHDFOverview(TestBase):
         self.assertTrue(hasattr(_overview, 'save'))
         self.assertTrue(hasattr(_overview, 'unknowns_discovery'))
 
+    @with_bf
     @mock.patch('sys.stdout', new_callable=io.StringIO)
-    def test_discoveries(self, mock_stdout):
+    def test_discoveries(self, _bf: File, mock_stdout):
         self.f.add_module('SIS crate')
-
-        _bf = self.bf
-        _overview = self.overview
+        _bf._map_file()  # re-map file
+        _overview = self.create_overview(_bf)
 
         # HDFOverview.control_discovery()
         with mock.patch.object(
@@ -161,10 +158,10 @@ class TestHDFOverview(TestBase):
         mock_stdout.seek(0)
         self.assertEqual(mock_stdout.getvalue(), '')
 
+    @with_bf
     @mock.patch('sys.stdout', new_callable=io.StringIO)
-    def test_report_controls(self, mock_stdout):
-        _bf = self.bf
-        _overview = self.overview
+    def test_report_controls(self, _bf: File, mock_stdout):
+        _overview = self.create_overview(_bf)
 
         # HDFOverview.report_control_configs                        ----
         control = _bf.controls['Waveform']
@@ -235,10 +232,10 @@ class TestHDFOverview(TestBase):
             mock_stdout.seek(0)
             self.assertEqual(mock_stdout.getvalue(), '')
 
+    @with_bf
     @mock.patch('sys.stdout', new_callable=io.StringIO)
-    def test_report_details(self, mock_stdout):
-        _bf = self.bf
-        _overview = self.overview
+    def test_report_details(self, _bf: File, mock_stdout):
+        _overview = self.create_overview(_bf)
 
         with mock.patch.multiple(
                 _overview.__class__,
@@ -251,12 +248,12 @@ class TestHDFOverview(TestBase):
             self.assertTrue(mock_values['report_controls'].called)
             self.assertTrue(mock_values['report_msi'].called)
 
+    @with_bf
     @mock.patch('sys.stdout', new_callable=io.StringIO)
-    def test_report_digitizers(self, mock_stdout):
+    def test_report_digitizers(self, _bf: File, mock_stdout):
         self.f.add_module('SIS crate')
-
-        _bf = self.bf
-        _overview = self.overview
+        _bf._map_file()  # re-map file
+        _overview = self.create_overview(_bf)
 
         # HDFOverview.report_digitizer_configs                      ----
         digi = _bf.digitizers['SIS 3301']
@@ -336,10 +333,10 @@ class TestHDFOverview(TestBase):
             mock_stdout.seek(0)
             self.assertEqual(mock_stdout.getvalue(), '')
 
+    @with_bf
     @mock.patch('sys.stdout', new_callable=io.StringIO)
-    def test_report_general(self, mock_stdout):
-        _bf = self.bf
-        _overview = self.overview
+    def test_report_general(self, _bf: File, mock_stdout):
+        _overview = self.create_overview(_bf)
 
         with mock.patch.object(
                 _bf.__class__, 'info',
@@ -349,10 +346,10 @@ class TestHDFOverview(TestBase):
             self.assertNotEqual(mock_stdout.getvalue(), '')
             self.assertTrue(mock_info.called)
 
+    @with_bf
     @mock.patch('sys.stdout', new_callable=io.StringIO)
-    def test_report_msi(self, mock_stdout):
-        _bf = self.bf
-        _overview = self.overview
+    def test_report_msi(self, _bf: File, mock_stdout):
+        _overview = self.create_overview(_bf)
 
         # HDFOverview.report_msi_configs                            ----
         msi = _bf.msi['Discharge']
@@ -423,10 +420,10 @@ class TestHDFOverview(TestBase):
             mock_stdout.seek(0)
             self.assertEqual(mock_stdout.getvalue(), '')
 
+    @with_bf
     @mock.patch('sys.stdout', new_callable=io.StringIO)
-    def test_print(self, mock_stdout):
-        _bf = self.bf
-        _overview = self.overview
+    def test_print(self, _bf: File, mock_stdout):
+        _overview = self.create_overview(_bf)
 
         with mock.patch.object(_bf.__class__, 'info',
                                new_callable=mock.PropertyMock,
@@ -443,11 +440,11 @@ class TestHDFOverview(TestBase):
             self.assertTrue(mock_values['report_discovery'].called)
             self.assertTrue(mock_values['report_details'].called)
 
+    @with_bf
     @mock.patch('__main__.__builtins__.open',
                 new_callable=mock.mock_open)
-    def test_save(self, mock_o):
-        _bf = self.bf
-        _overview = self.overview
+    def test_save(self, _bf: File, mock_o):
+        _overview = self.create_overview(_bf)
 
         with mock.patch.object(
                 _overview.__class__, 'print',

--- a/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
+++ b/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
@@ -21,7 +21,7 @@ from bapsflib._hdf.maps import HDFMap
 from bapsflib._hdf.maps.digitizers.sis3301 import HDFMapDigiSIS3301
 from unittest import mock
 
-from . import TestBase
+from . import (TestBase, with_bf)
 from ..file import File
 from ..hdfreadcontrol import HDFReadControl
 from ..hdfreaddata import (build_sndr_for_simple_dset,
@@ -45,12 +45,14 @@ class TestHDFReadData(TestBase):
     def tearDown(self):
         super().tearDown()
 
+    @with_bf
     @mock.patch('bapsflib._hdf.utils.hdfreaddata.HDFReadControl')
     @mock.patch('bapsflib._hdf.utils.hdfreaddata.condition_controls')
     @mock.patch.object(HDFMap, 'controls',
                        new_callable=mock.PropertyMock,
                        return_value={'control': None})
-    def test_adding_controls(self, mock_cmap, mock_cc, mock_cdata):
+    def test_adding_controls(self, _bf: File,
+                             mock_cmap, mock_cc, mock_cdata):
         """Test adding control device data to digitizer data."""
         # setup HDF5
         sn_size = 50
@@ -65,7 +67,7 @@ class TestHDFReadData(TestBase):
         bc_indices = np.where(bc_arr)
         brd = bc_indices[0][0]
         ch = bc_indices[1][0]
-        _bf = self.bf
+        _bf._map_file()  # re-map file
         digi_path = 'Raw data + config/SIS 3301'
         dset_name = config_name + " [{}:{}]".format(brd, ch)
         dset_path = digi_path + '/' + dset_name
@@ -220,7 +222,8 @@ class TestHDFReadData(TestBase):
         mock_cdata.reset_mock()
         mock_cc.reset_mock()
 
-    def test_kwarg_adc(self):
+    @with_bf
+    def test_kwarg_adc(self, _bf: File):
         """Test handling of keyword `adc`."""
         # Handling should be done by mapping function
         # `construct_dset_name` which is covered by the associated
@@ -237,7 +240,7 @@ class TestHDFReadData(TestBase):
         brd = bc_indices[0][0]
         ch = bc_indices[1][0]
 
-        _bf = self.bf
+        _bf._map_file()  # re-map file
         _map = _bf.file_map.digitizers[digi]
         with mock.patch.object(
                 HDFMapDigiSIS3301, 'construct_dataset_name',
@@ -268,7 +271,8 @@ class TestHDFReadData(TestBase):
             self.assertEqual(data.info['adc'], adc)
             mock_cdn.reset_mock()
 
-    def test_kwarg_board(self):
+    @with_bf
+    def test_kwarg_board(self, _bf: File):
         """Test handling of argument `board`."""
         # Handling should be done by mapping function
         # `construct_dset_name` which is covered by the associated
@@ -285,7 +289,10 @@ class TestHDFReadData(TestBase):
         brd = bc_indices[0][0]
         ch = bc_indices[1][0]
 
-        _bf = self.bf
+        # re-map file
+        _bf._map_file()
+
+        # run assertions
         _map = _bf.file_map.digitizers[digi]
         with mock.patch.object(
                 HDFMapDigiSIS3301, 'construct_dataset_name',
@@ -307,7 +314,8 @@ class TestHDFReadData(TestBase):
                 self.assertTrue(mock_cdn.called)
                 mock_cdn.reset_mock()
 
-    def test_kwarg_channel(self):
+    @with_bf
+    def test_kwarg_channel(self, _bf: File):
         """Test handling of argument `channel`."""
         # Handling should be done by mapping function
         # `construct_dset_name` which is covered by the associated
@@ -324,7 +332,7 @@ class TestHDFReadData(TestBase):
         brd = bc_indices[0][0]
         ch = bc_indices[1][0]
 
-        _bf = self.bf
+        _bf._map_file()  # re-map file
         _map = _bf.file_map.digitizers[digi]
         with mock.patch.object(
                 HDFMapDigiSIS3301, 'construct_dataset_name',
@@ -346,7 +354,8 @@ class TestHDFReadData(TestBase):
                 self.assertTrue(mock_cdn.called)
                 mock_cdn.reset_mock()
 
-    def test_kwarg_config_name(self):
+    @with_bf
+    def test_kwarg_config_name(self, _bf: File):
         """Test handling of keyword `digitizer`."""
         # Handling should be done by mapping function
         # `construct_dset_name` which is covered by the associated
@@ -363,7 +372,7 @@ class TestHDFReadData(TestBase):
         brd = bc_indices[0][0]
         ch = bc_indices[1][0]
 
-        _bf = self.bf
+        _bf._map_file()  # re-map file
         _map = _bf.file_map.digitizers[digi]
         with mock.patch.object(
                 HDFMapDigiSIS3301, 'construct_dataset_name',
@@ -396,7 +405,8 @@ class TestHDFReadData(TestBase):
                                  config_name)
                 mock_cdn.reset_mock()
 
-    def test_kwarg_digitizer(self):
+    @with_bf
+    def test_kwarg_digitizer(self, _bf: File):
         """Test handling of keyword `digitizer`."""
         # Note: cases were an exception is raise is covered by
         #       `test_raise_errors`
@@ -411,7 +421,7 @@ class TestHDFReadData(TestBase):
         bc_indices = np.where(bc_arr)
         brd = bc_indices[0][0]
         ch = bc_indices[1][0]
-        _bf = self.bf
+        _bf._map_file()  # re-map file
 
         # `digitizer` is None and "main" digitizer was identified
         with self.assertWarns(UserWarning):
@@ -426,7 +436,8 @@ class TestHDFReadData(TestBase):
         self.assertDataObj(data, _bf)
         self.assertEqual(data.info['digitizer'], digi)
 
-    def test_kwarg_keep_bits(self):
+    @with_bf
+    def test_kwarg_keep_bits(self, _bf: File):
         """Test behavior of keyword `keep_bits`."""
         # setup
         sn_size = 50
@@ -441,7 +452,7 @@ class TestHDFReadData(TestBase):
         bc_indices = np.where(bc_arr)
         brd = bc_indices[0][0]
         ch = bc_indices[1][0]
-        _bf = self.bf
+        _bf._map_file()  # re-map file
         digi_path = 'Raw data + config/SIS 3301'
         dset_name = config_name + " [{}:{}]".format(brd, ch)
         dset_path = digi_path + '/' + dset_name
@@ -492,11 +503,11 @@ class TestHDFReadData(TestBase):
         self.assertDataArrayValues(data, dset, indices, keep_bits=True)
         self.assertEqual(data.info['signal units'], u.bit)
 
-
+    @with_bf
     @mock.patch(
         'bapsflib._hdf.utils.hdfreaddata.do_shotnum_intersection',
         side_effect=do_shotnum_intersection)
-    def test_kwarg_intersection_set(self, mock_inter):
+    def test_kwarg_intersection_set(self, _bf: File, mock_inter):
         """Test behavior of keyword `intersection_set`."""
         # Note: `intersection_set` has no affect when calling with
         #       `index` and no `add_controls`
@@ -514,7 +525,7 @@ class TestHDFReadData(TestBase):
         bc_indices = np.where(bc_arr)
         brd = bc_indices[0][0]
         ch = bc_indices[1][0]
-        _bf = self.bf
+        _bf._map_file()  # re-map file
         digi_path = 'Raw data + config/SIS 3301'
         dset_name = config_name + " [{}:{}]".format(brd, ch)
         dset_path = digi_path + '/' + dset_name
@@ -597,7 +608,8 @@ class TestHDFReadData(TestBase):
         self.assertFalse(mock_inter.called)
         mock_inter.reset_mock()
 
-    def test_misc_behavior(self):
+    @with_bf
+    def test_misc_behavior(self, _bf: File):
         """Test miscellaneous behavior"""
         # setup
         sn_size = 50
@@ -612,7 +624,7 @@ class TestHDFReadData(TestBase):
         bc_indices = np.where(bc_arr)
         brd = bc_indices[0][0]
         ch = bc_indices[1][0]
-        _bf = self.bf
+        _bf._map_file()  # re-map file
         digi_path = 'Raw data + config/SIS 3301'
         dset_name = config_name + " [{}:{}]".format(brd, ch)
         dset_path = digi_path + '/' + dset_name
@@ -709,8 +721,8 @@ class TestHDFReadData(TestBase):
         data.info['clock rate'] = old_cr
         data.info['sample average'] = old_ave
 
-
-    def test_raise_errors(self):
+    @with_bf
+    def test_raise_errors(self, _bf: File):
         """Test scenarios that cause exceptions to be raised."""
         # 1. input file object `hdf_obj` is not a bapsflib file object
         #    bapsflib._hdf.utils.file.File
@@ -721,8 +733,6 @@ class TestHDFReadData(TestBase):
         # 5. specified `digitizer` is not a mapped digitizer
         # 6. specified `index` in not a valid type
         #
-        _bf = self.bf
-
         # not a bapsflib._hdf.utils.file.File object                 (1)
         self.assertRaises(TypeError, HDFReadData, None, 0, 0)
 
@@ -748,7 +758,7 @@ class TestHDFReadData(TestBase):
         bc_indices = np.where(bc_arr)
         brd = bc_indices[0][0]
         ch = bc_indices[1][0]
-        _bf = self.bf
+        _bf._map_file()  # re-map file
 
         # test
         with mock.patch.object(HDFMap, 'main_digitizer',
@@ -767,7 +777,8 @@ class TestHDFReadData(TestBase):
                           digitizer=digi, adc=adc,
                           config_name=config_name)
 
-    def test_read_w_index(self):
+    @with_bf
+    def test_read_w_index(self, _bf: File):
         """Test reading data using `index` keyword."""
         # setup
         sn_size =50
@@ -782,7 +793,7 @@ class TestHDFReadData(TestBase):
         bc_indices = np.where(bc_arr)
         brd = bc_indices[0][0]
         ch = bc_indices[1][0]
-        _bf = self.bf
+        _bf._map_file()  # re-map file
         digi_path = 'Raw data + config/SIS 3301'
         dset_name = config_name + " [{}:{}]".format(brd, ch)
         dset_path = digi_path + '/' + dset_name
@@ -854,6 +865,7 @@ class TestHDFReadData(TestBase):
                                index=[-sn_size - 10])
             self.assertDataObj(data, _bf)
 
+    @with_bf
     @mock.patch('bapsflib._hdf.utils.hdfreaddata.condition_shotnum',
                 side_effect=condition_shotnum)
     @mock.patch(
@@ -862,7 +874,8 @@ class TestHDFReadData(TestBase):
     @mock.patch(
         'bapsflib._hdf.utils.hdfreaddata.do_shotnum_intersection',
         side_effect=do_shotnum_intersection)
-    def test_read_w_shotnum(self, mock_inter, mock_build_sndr, mock_cs):
+    def test_read_w_shotnum(self, _bf: File, mock_inter,
+                            mock_build_sndr, mock_cs):
         """Test reading data using `index` keyword."""
         # setup
         sn_size = 50
@@ -877,7 +890,7 @@ class TestHDFReadData(TestBase):
         bc_indices = np.where(bc_arr)
         brd = bc_indices[0][0]
         ch = bc_indices[1][0]
-        _bf = self.bf
+        _bf._map_file()  # re-map file
         digi_path = 'Raw data + config/SIS 3301'
         dset_name = config_name + " [{}:{}]".format(brd, ch)
         dset_path = digi_path + '/' + dset_name

--- a/bapsflib/_hdf/utils/tests/test_helpers.py
+++ b/bapsflib/_hdf/utils/tests/test_helpers.py
@@ -17,7 +17,7 @@ import unittest as ut
 from bapsflib._hdf.maps.controls.waveform import HDFMapControlWaveform
 from numpy.lib import recfunctions as rfn
 
-from . import TestBase
+from . import (TestBase, with_bf)
 from ..file import File
 from ..helpers import (build_shotnum_dset_relation,
                        condition_controls, condition_shotnum,
@@ -245,34 +245,34 @@ class TestConditionControls(TestBase):
     def tearDown(self):
         super().tearDown()
 
-    def test_input_failures(self):
+    @with_bf
+    def test_input_failures(self, _bf: File):
         """Test input failures of `controls`"""
         # `controls` is Null
-        self.assertRaises(ValueError,
-                          condition_controls, self.bf, [])
+        self.assertRaises(ValueError, condition_controls, _bf, [])
 
         # `controls` is not a string or Iterable
-        self.assertRaises(TypeError,
-                          condition_controls, self.bf, True)
+        self.assertRaises(TypeError, condition_controls, _bf, True)
 
         # 'controls` element is not a str or tuple
         self.assertRaises(TypeError,
                           condition_controls,
-                          self.bf, ['Waveform', 8])
+                          _bf, ['Waveform', 8])
 
         # `controls` tuple element has length > 2
         self.assertRaises(ValueError,
                           condition_controls,
-                          self.bf, [('Waveform', 'c1', 'c2')])
+                          _bf, [('Waveform', 'c1', 'c2')])
 
-    def test_file_w_one_control(self):
+    @with_bf
+    def test_file_w_one_control(self, _bf: File):
         """
         Test `controls` conditioning for file with one control device.
         """
         # set one control device
         self.f.add_module('Waveform',
                           mod_args={'n_configs': 1, 'sn_size': 100})
-        _bf = self.bf
+        _bf._map_file()  # re-map file
 
         # ---- Waveform w/ one Configuration                        ----
         # conditions that work
@@ -299,7 +299,7 @@ class TestConditionControls(TestBase):
 
         # ---- Waveform w/ three Configurations                     ----
         self.f.modules['Waveform'].knobs.n_configs = 3
-        _bf = self.bf
+        _bf._map_file()  # re-map file
 
         # conditions that work
         con_list = [
@@ -321,7 +321,8 @@ class TestConditionControls(TestBase):
                               condition_controls, _bf,
                               og_con)
 
-    def test_file_w_multiple_controls(self):
+    @with_bf
+    def test_file_w_multiple_controls(self, _bf: File):
         """
         Test `controls` conditioning for file with multiple (2) control
         devices.
@@ -331,9 +332,9 @@ class TestConditionControls(TestBase):
                           {'n_configs': 1, 'sn_size': 100})
         self.f.add_module('6K Compumotor',
                           {'n_configs': 1, 'sn_size': 100})
+        _bf._map_file()  # re-map file
 
         # ---- 1 Waveform Config & 1 6K Config                      ----
-        _bf = self.bf
         sixk_cspec = self.f.modules['6K Compumotor'].config_names[0]
 
         # conditions that work
@@ -382,7 +383,7 @@ class TestConditionControls(TestBase):
 
         # ---- 3 Waveform Config & 1 6K Config                      ----
         self.f.modules['Waveform'].knobs.n_configs = 3
-        _bf = self.bf
+        _bf._map_file()  # re-map file
         sixk_cspec = self.f.modules['6K Compumotor'].config_names[0]
 
         # conditions that work
@@ -432,7 +433,7 @@ class TestConditionControls(TestBase):
         # ---- 1 Waveform Config & 3 6K Config                      ----
         self.f.modules['Waveform'].knobs.n_configs = 1
         self.f.modules['6K Compumotor'].knobs.n_configs = 3
-        _bf = self.bf
+        _bf._map_file()  # re-map file
         sixk_cspec = self.f.modules['6K Compumotor'].config_names
 
         # conditions that work
@@ -477,7 +478,7 @@ class TestConditionControls(TestBase):
 
         # ---- 3 Waveform Config & 3 6K Config                      ----
         self.f.modules['Waveform'].knobs.n_configs = 3
-        _bf = self.bf
+        _bf._map_file()  # re-map file
         sixk_cspec = self.f.modules['6K Compumotor'].config_names
 
         # conditions that work
@@ -522,7 +523,8 @@ class TestConditionControls(TestBase):
                               condition_controls, _bf,
                               og_con)
 
-    def test_controls_w_same_contype(self):
+    @with_bf
+    def test_controls_w_same_contype(self, _bf: File):
         """
         Test `controls` conditioning for multiple devices with the
         same contype.
@@ -532,7 +534,7 @@ class TestConditionControls(TestBase):
                           {'n_configs': 1, 'sn_size': 100})
         self.f.add_module('6K Compumotor',
                           {'n_configs': 1, 'sn_size': 100})
-        _bf = self.bf
+        _bf._map_file()  # re-map file
 
         # fake 6K as contype.waveform
         _bf.file_map.controls['6K Compumotor'].info['contype'] = \

--- a/bapsflib/lapd/_hdf/tests/__init__.py
+++ b/bapsflib/lapd/_hdf/tests/__init__.py
@@ -12,8 +12,13 @@ import unittest as ut
 
 from bapsflib._hdf import File as BaseFile
 from bapsflib._hdf.maps import FauxHDFBuilder
+from bapsflib._hdf.utils.tests import with_bf
+from functools import wraps
 
 from ..file import File
+
+
+__all__ = ['TestBase', 'with_bf', 'with_lapdf']
 
 
 def method_overridden(cls, obj, method: str) -> bool:

--- a/bapsflib/lapd/_hdf/tests/__init__.py
+++ b/bapsflib/lapd/_hdf/tests/__init__.py
@@ -23,6 +23,19 @@ def method_overridden(cls, obj, method: str) -> bool:
     return obj_method and base_method
 
 
+def with_lapdf(func):
+    """
+    Context decorator for managing the opening and closing LaPD HDF5
+    Files :class:`bapsflib.lapd._hdf.file.File`.  Intended for use on
+    test methods.
+    """
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        with File(self.f.filename) as lapdf:
+            return func(self, lapdf, *args, *kwargs)
+    return wrapper
+
+
 class TestBase(ut.TestCase):
     """Base test class for all test classes here."""
 

--- a/bapsflib/lapd/_hdf/tests/__init__.py
+++ b/bapsflib/lapd/_hdf/tests/__init__.py
@@ -53,7 +53,7 @@ class TestBase(ut.TestCase):
         cls.f = FauxHDFBuilder()
 
     def tearDown(self):
-        self.f.remove_all_modules()
+        self.f.reset()
 
     @classmethod
     def tearDownClass(cls):

--- a/bapsflib/lapd/_hdf/tests/__init__.py
+++ b/bapsflib/lapd/_hdf/tests/__init__.py
@@ -17,8 +17,7 @@ from functools import wraps
 
 from ..file import File
 
-
-__all__ = ['TestBase', 'with_bf', 'with_lapdf']
+__all__ = ['BaseFile', 'TestBase', 'with_bf', 'with_lapdf']
 
 
 def method_overridden(cls, obj, method: str) -> bool:

--- a/bapsflib/lapd/_hdf/tests/__init__.py
+++ b/bapsflib/lapd/_hdf/tests/__init__.py
@@ -61,19 +61,6 @@ class TestBase(ut.TestCase):
         super().tearDownClass()
         cls.f.cleanup()
 
-    @property
-    def bf(self) -> BaseFile:
-        """Opened BaPSF HDF5 File instance."""
-        return BaseFile(self.f.filename,
-                        control_path='Raw data + config',
-                        digitizer_path='Raw data + config',
-                        msi_path='MSI')
-
-    @property
-    def lapdf(self) -> File:
-        """Opened LaPD HDF5 File instance."""
-        return File(self.f.filename)
-
     def assertMethodOverride(self, base_class, obj, method):
         """
         Assert the class that instantiated `obj` over-road `base_class`

--- a/bapsflib/lapd/_hdf/tests/test_file.py
+++ b/bapsflib/lapd/_hdf/tests/test_file.py
@@ -18,13 +18,13 @@ import unittest as ut
 from bapsflib._hdf.maps.hdfmap import HDFMap
 from unittest import mock
 
-from . import TestBase
+from . import (BaseFile, TestBase, with_bf, with_lapdf)
 from ..file import File
 from ..lapdmap import LaPDMap
 from ..lapdoverview import LaPDOverview
 
 
-class TestLaPDOverview(TestBase):
+class TestLaPDFile(TestBase):
     """
     Test case for :class:`~bapsflib.lapd._hdf.file.File`
     """
@@ -35,9 +35,9 @@ class TestLaPDOverview(TestBase):
     def tearDown(self):
         super().tearDown()
 
-    def test_file(self):
-        _lapdf = self.lapdf
-
+    @with_bf
+    @with_lapdf
+    def test_file(self, _lapdf: File, _bf: BaseFile):
         # must subclass `bapsflib._hdf.utils.file.File`
         self.assertIsInstance(_lapdf, bapsflib._hdf.utils.file.File)
 
@@ -75,7 +75,7 @@ class TestLaPDOverview(TestBase):
         # subclass `_build_info` in appended
         with mock.patch.object(bapsflib._hdf.utils.file.File,
                                '_build_info',
-                               side_effect=self.bf._build_info) \
+                               side_effect=_bf._build_info) \
                 as mock_bi_super:
             _lapdf._build_info()
             self.assertTrue(mock_bi_super.called)

--- a/bapsflib/lapd/_hdf/tests/test_lapdmap.py
+++ b/bapsflib/lapd/_hdf/tests/test_lapdmap.py
@@ -17,7 +17,8 @@ import unittest as ut
 from bapsflib._hdf import HDFMap
 from unittest import mock
 
-from . import TestBase
+from . import (TestBase, with_lapdf)
+from ..file import File
 from ..lapdmap import LaPDMap
 
 
@@ -26,14 +27,14 @@ class TestLaPDMap(TestBase):
     Test case for :class:`~bapsflib.lapd._hdf.lapdmap.LaPDMap`
     """
 
-    @property
-    def map(self):
-        """LaPD map object"""
-        return LaPDMap(self.lapdf)
+    @staticmethod
+    def create_map(file):
+        """Generate LaPD map object"""
+        return LaPDMap(file)
 
-    def test_mapping(self):
-        _lapdf = self.lapdf
-        _map = self.map
+    @with_lapdf
+    def test_mapping(self, _lapdf: File):
+        _map = self.create_map(_lapdf)
 
         # LaPDMap subclasses HDFMap
         self.assertIsInstance(_map, HDFMap)
@@ -148,7 +149,7 @@ class TestLaPDMap(TestBase):
                                new_callable=mock.PropertyMock,
                                return_value=False) as mock_il:
             with self.assertWarns(UserWarning):
-                _map = self.map
+                _map = self.create_map(_lapdf)
                 self.assertTrue(mock_il.called)
 
 

--- a/bapsflib/lapd/_hdf/tests/test_lapdoverview.py
+++ b/bapsflib/lapd/_hdf/tests/test_lapdoverview.py
@@ -38,11 +38,6 @@ class TestLaPDOverview(TestBase):
 
     def tearDown(self):
         super().tearDown()
-        del self.f['Raw data + config/Unknown']
-
-    @property
-    def overview(self):
-        return self.create_overview(self.lapdf)
 
     @staticmethod
     def create_overview(file):

--- a/bapsflib/lapd/_hdf/tests/test_lapdoverview.py
+++ b/bapsflib/lapd/_hdf/tests/test_lapdoverview.py
@@ -17,13 +17,14 @@ import unittest as ut
 from bapsflib._hdf.utils.hdfoverview import HDFOverview
 from unittest import mock
 
-from . import TestBase
+from . import (TestBase, with_lapdf)
+from ..file import File
 from ..lapdoverview import LaPDOverview
 
 
 class TestLaPDOverview(TestBase):
     """
-    Test case for :class:`~bapsflib.lapd._hdf.lapdoverview.HDFOverview`
+    Test case for :class:`~bapsflib.lapd._hdf.lapdoverview.LaPDOverview`
     """
 
     def setUp(self):
@@ -47,9 +48,9 @@ class TestLaPDOverview(TestBase):
     def create_overview(file):
         return LaPDOverview(file)
 
-    def test_overview(self):
-        _lapdf = self.lapdf
-        _overview = self.overview
+    @with_lapdf
+    def test_overview(self, _lapdf: File):
+        _overview = self.create_overview(_lapdf)
 
         # LaPDOverview subclasses HDFOverview
         self.assertIsInstance(_overview, LaPDOverview)


### PR DESCRIPTION
What was done:

1. created `appveyor.yml` for AppVeyor support
    * for running tests on Windows platform
    * tests are run on python 3.5, 3.6, and 3.7 environments
1. improved context managing of opening/closing of files `bapsflib._hdf.utils.file.File` and `bapsflib.lapd._hdf.file.File`
    * this is done by creating the decorators `with_bf` and `with_lapdf` and implementing them in all appropriate tests
    * by proper context managing, the temporary HDF5 file can be properly removed/deleted when tests are complete