### PR TITLE
Add Plasma Constants and Paramters

### DIFF
--- a/bapsflib/lapd/constants/constants.py
+++ b/bapsflib/lapd/constants/constants.py
@@ -18,26 +18,21 @@ from astropy.utils.exceptions import AstropyWarning
 from typing import Tuple
 
 
-class BaPSFConstant(Constant):
-    """BaPSF Constant"""
-    default_reference = 'Basic Plasma Science Facility'
+class LaPDConstant(Constant):
+    """LaPD Constant"""
+    default_reference = 'Large Plasma Device'
     _registry = {}
     _has_incompatible_units = set()
 
-    def __new__(cls, abbrev, name, value, unit, uncertainty,
-                reference=default_reference, system=None):
-        return super().__new__(cls, abbrev, name, value, unit,
-                               uncertainty, reference, system)
 
-
-#: BaPSF Constant: nominal distance between LaPD ports
-port_spacing = BaPSFConstant('port_spacing', 'LaPD port spacing',
-                             31.95, 'cm', 1.0, system='cgs')
+#: LaPD Constant: nominal distance between LaPD ports
+port_spacing = LaPDConstant('port_spacing', 'LaPD port spacing',
+                            31.95, 'cm', 1.0, system='cgs')
 port_spacing.__doc__ += ': nominal distance between LaPD ports'
 
-#: BaPSF Constant: LaPD :math:`z = 0` reference port (most Northern
+#: LaPD Constant: LaPD :math:`z = 0` reference port (most Northern
 #: port and :math:`+z` points South towards south cathode)
-ref_port = BaPSFConstant('ref_port', 'LaPD reference port number', 53,
+ref_port = LaPDConstant('ref_port', 'LaPD reference port number', 53,
                          u.dimensionless_unscaled, 0, system=None)
 ref_port.__doc__ += (": LaPD :math:`z = 0` reference port (most "
                      "Northern port and :math:`+z` points South "
@@ -81,19 +76,19 @@ class SouthCathode(object):
             warnings.simplefilter('ignore', AstropyWarning)
 
             if val.year <= val.year:
-                self._diameter = BaPSFConstant(
+                self._diameter = LaPDConstant(
                     'diameter',
                     "Diameter of LaPD's south 'main' cathode",
                     60.0, 'cm',
                     1.0, system='cgs'
                 )
-                self._z = BaPSFConstant(
+                self._z = LaPDConstant(
                     'z',
                     "Axial location of LaPD's south 'main' cathode",
                     1700.0, 'cm',
                     1.0, system='cgs'
                 )
-                self._anode_z = BaPSFConstant(
+                self._anode_z = LaPDConstant(
                     'anode_z',
                     "Axial location of LaPD's south 'main' anode",
                     1650.0, 'cm',
@@ -103,17 +98,17 @@ class SouthCathode(object):
                 self._lifespan = (NotImplemented, NotImplemented)
 
     @property
-    def anode_z(self) -> BaPSFConstant:
+    def anode_z(self) -> LaPDConstant:
         """LaPD z location of the anode"""
         return self._anode_z
 
     @property
-    def diameter(self) -> BaPSFConstant:
+    def diameter(self) -> LaPDConstant:
         """Diameter of LaPD's south 'main' cathode"""
         return self._diameter
 
     @property
-    def z(self) -> BaPSFConstant:
+    def z(self) -> LaPDConstant:
         """LaPD z location of the cathode"""
         return self._z
 

--- a/bapsflib/lapd/constants/tests/test_constants.py
+++ b/bapsflib/lapd/constants/tests/test_constants.py
@@ -16,7 +16,7 @@ import unittest as ut
 
 from astropy.constants import Constant
 from bapsflib.lapd.constants import (port_spacing, ref_port)
-from bapsflib.lapd.constants.constants import BaPSFConstant
+from bapsflib.lapd.constants.constants import LaPDConstant
 
 
 class TestConstants(ut.TestCase):
@@ -24,19 +24,19 @@ class TestConstants(ut.TestCase):
     Test LaPD constants. (:mod:`bapsflib.lapd.constants.constants`)
     """
 
-    def test_BaPSFConstant(self):
-        self.assertTrue(issubclass(BaPSFConstant, Constant))
-        self.assertEqual(BaPSFConstant.default_reference,
-                         "Basic Plasma Science Facility")
+    def test_LaPDConstant(self):
+        self.assertTrue(issubclass(LaPDConstant, Constant))
+        self.assertEqual(LaPDConstant.default_reference,
+                         "Large Plasma Device")
 
     def test_port_spacing(self):
-        self.assertIsInstance(port_spacing, BaPSFConstant)
+        self.assertIsInstance(port_spacing, LaPDConstant)
         self.assertEqual(port_spacing.value, 31.95)
         self.assertEqual(port_spacing.unit, u.cm)
         self.assertEqual(port_spacing.uncertainty, 1.0)
 
     def test_ref_port(self):
-        self.assertIsInstance(ref_port, BaPSFConstant)
+        self.assertIsInstance(ref_port, LaPDConstant)
         self.assertEqual(ref_port.value, 53)
         self.assertEqual(ref_port.unit, u.dimensionless_unscaled)
 

--- a/bapsflib/plasma/__init__.py
+++ b/bapsflib/plasma/__init__.py
@@ -8,6 +8,7 @@
 # License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
 #   license terms and contributor agreement.
 #
-from . import core
+from . import constants
+from . import parameters
 
-__all__ = ['core']
+__all__ = ['constants', 'parameters']

--- a/bapsflib/plasma/constants.py
+++ b/bapsflib/plasma/constants.py
@@ -14,18 +14,19 @@ Constants are imported from :mod:`astropy.constants.codata2014`.
 """
 from astropy.constants.codata2014 import (
     c,
-    e, e_gauss, e_emu, e_esu,
+    e, e_gauss,
     eps0,
     g0,
     k_B,
     m_e, m_n, m_p, u,
     mu0,
 )
+from bapsflib.utils import BaPSFConstant
 from numpy import pi
 
 
 __all__ = ['c',
-           'e', 'e_gauss', 'e_emu', 'e_esu',
+           'e', 'e_gauss',
            'eps0',
            'g0',
            'k_B',
@@ -33,38 +34,69 @@ __all__ = ['c',
            'mu0',
            'pi']
 
-'''
-class BaPSFConstant(Constant):
-    """BaPSF Constant"""
-    default_reference = 'Basic Plasma Facility'
-    _registry = {}
-    _has_incompatible_units = set()
-
-
-AMU = BaPSFConstant(**{
-    'abbrev': 'AMU',
-    'name': 'atomic mass unit',
-    'value': const.u.cgs.value,
-    'unit': const.u.cgs.unit,
-    'uncertainty': (const.u.uncertainty * const.u.unit).cgs,
-    'system': 'cgs',
-})
-
-C = BaPSFConstant(**{
-    'abbrev': 'C',
-    'name': 'speed of light in vacuum',
-    'value': const.c.cgs.value,
-    'unit': const.c.cgs.unit,
-    'uncertainty': (const.c.uncertainty * const.c.unit).cgs,
-    'system': 'cgs',
-})
-
+# rename some attributes for clarity
 e = BaPSFConstant(**{
     'abbrev': 'e',
-    'name': 'elementary charge',
-    'value': const.e.cgs.value,
-    'unit': const.e.cgs.unit,
-    'uncertainty': (const.e.uncertainty * const.e.unit).cgs,
-    'system': 'cgs',
+    'name': 'Elementary charge',
+    'value': e.value,
+    'unit': e.unit.name,
+    'uncertainty': e.uncertainty,
+    'system': e.system,
 })
-'''
+e_gauss = BaPSFConstant(**{
+    'abbrev': 'e_gauss',
+    'name': 'Elementary charge',
+    'value': e_gauss.value,
+    'unit': e_gauss.unit.name,
+    'uncertainty': e_gauss.uncertainty,
+    'system': e_gauss.system,
+})
+u = BaPSFConstant(**{
+    'abbrev': 'u',
+    'name': 'Atomic mass unit',
+    'value': u.value,
+    'unit': u.unit.name,
+    'uncertainty': u.uncertainty,
+    'system': u.system,
+})
+
+# clean up
+del BaPSFConstant
+
+# The following code is modified from astropy.constants to produce a
+# table containing information on the constants.
+
+# initialize table
+_tb_div = ((8 * '=') + ' '
+           + (17 * '=') + ' '
+           + (10 * '=') + ' '
+           + (7 * '=') + ' '
+           + (44 * '='))
+_lines = [
+    'The following constants are available:\n',
+    _tb_div,
+    '{0:^8} {1:^17} {2:^10} {3:^7} {4}'.format('Name', 'Value', 'Units',
+                                              'System', 'Description'),
+    _tb_div,
+    '{0:^8} {1:^17.12f} {2:^10} {3:^7} {4}'.format(
+        'pi', pi, '', '',
+        'Ratio of circumference to diameter of circle'),
+]
+
+# add lines to table
+_constants = [eval(item) for item in dir() if item[0] != '_' and item != 'pi']
+_const = None
+for _const in _constants:
+    _lines.append('{0:^8} {1:^17.12g} {2:^10} {3:^7} {4}'
+                  .format(_const.abbrev, _const.value,
+                          _const._unit_string, _const.system,
+                          _const.name))
+
+_lines.append(_lines[1])
+
+# add table to docstrings
+__doc__ += '\n'
+__doc__ += '\n'.join(_lines)
+
+# remove clutter from namespace
+del _const, _constants, _lines, _tb_div,

--- a/bapsflib/plasma/constants.py
+++ b/bapsflib/plasma/constants.py
@@ -1,0 +1,70 @@
+# This file is part of the bapsflib package, a Python toolkit for the
+# BaPSF group at UCLA.
+#
+# http://plasma.physics.ucla.edu/
+#
+# Copyright 2017-2019 Erik T. Everson and contributors
+#
+# License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
+#   license terms and contributor agreement.
+#
+"""Useful Physical Constants
+
+Constants are imported from :mod:`astropy.constants.codata2014`.
+"""
+from astropy.constants.codata2014 import (
+    c,
+    e, e_gauss, e_emu, e_esu,
+    eps0,
+    g0,
+    k_B,
+    m_e, m_n, m_p, u,
+    mu0,
+)
+from numpy import pi
+
+
+__all__ = ['c',
+           'e', 'e_gauss', 'e_emu', 'e_esu',
+           'eps0',
+           'g0',
+           'k_B',
+           'm_e', 'm_n', 'm_p', 'u',
+           'mu0',
+           'pi']
+
+'''
+class BaPSFConstant(Constant):
+    """BaPSF Constant"""
+    default_reference = 'Basic Plasma Facility'
+    _registry = {}
+    _has_incompatible_units = set()
+
+
+AMU = BaPSFConstant(**{
+    'abbrev': 'AMU',
+    'name': 'atomic mass unit',
+    'value': const.u.cgs.value,
+    'unit': const.u.cgs.unit,
+    'uncertainty': (const.u.uncertainty * const.u.unit).cgs,
+    'system': 'cgs',
+})
+
+C = BaPSFConstant(**{
+    'abbrev': 'C',
+    'name': 'speed of light in vacuum',
+    'value': const.c.cgs.value,
+    'unit': const.c.cgs.unit,
+    'uncertainty': (const.c.uncertainty * const.c.unit).cgs,
+    'system': 'cgs',
+})
+
+e = BaPSFConstant(**{
+    'abbrev': 'e',
+    'name': 'elementary charge',
+    'value': const.e.cgs.value,
+    'unit': const.e.cgs.unit,
+    'uncertainty': (const.e.uncertainty * const.e.unit).cgs,
+    'system': 'cgs',
+})
+'''

--- a/bapsflib/plasma/core.py
+++ b/bapsflib/plasma/core.py
@@ -15,14 +15,6 @@
 #
 """Core plasma parameters in (cgs)."""
 
-import astropy.constants as const
-import astropy.units as u
-import math
-
-from scipy import constants
-
-#pconst = constants.physical_constants
-
 '''
 class FloatUnit(float):
     """Template class for floats with a unit attribute."""
@@ -68,89 +60,4 @@ class IntUnit(int):
     def unit(self):
         """units of constant"""
         return self._unit
-'''
-'''
-# ---- length constants ----
-def rce(Bo, kTe, **kwargs):
-    """
-    electron gyroradius (cm)
-
-    .. math::
-
-        r_{ce} = \\frac{v_{T_{e}}}{\Omega_{ce}}
-
-    :param float Bo: magnetic field (in Gauss)
-    :param float kTe: electron temperature (in eV)
-
-    .. note:: see functions :func:`vTe` and :func:`oce`
-    """
-    _rce = vTe(kTe) / abs(oce(Bo))
-    return FloatUnit(_rce, 'cm')
-
-
-def rci(Bo, kTi, m_i, Z, **kwargs):
-    """
-    ion gyroradius (cm)
-
-    .. math::
-
-        r_{ci} = \\frac{v_{T_{i}}}{\Omega_{ci}}
-
-    :param float Bo: magnetic field (in Gauss)
-    :param float kTi: ion temperature (in eV)
-    :param float m_i: ion mass (in g)
-    :param int Z: ion charge number
-
-    .. note:: see functions :func:`vTi` and :func:`oci`
-    """
-    _rci = vTi(kTi, m_i) / oci(Bo, m_i, Z)
-    return FloatUnit(_rci, 'cm')
-
-
-# ---- velocity constants ----
-def VA(Bo, m_i, n_i, **kwargs):
-    """
-    Alfvén Velocity (in cm/s)
-
-    .. math::
-
-        V_{A} = \\frac{B_{o}}{\sqrt{4 \pi n_{i} m_{i}}}
-
-    :param float Bo: magnetic field (in Gauss)
-    :param float m_i: ion mass (in g)
-    :param float n_i: ion number density (in :math:`cm^{-3}`)
-    """
-    _VA = Bo / math.sqrt(4.0 * math.pi * n_i * m_i)
-    return FloatUnit(_VA, 'cm s^-1')
-
-
-def vTe(kTe, **kwargs):
-    """
-    electron thermal velocity (in cm/s)
-
-    .. math::
-
-        v_{T_{e}} = \sqrt{\\frac{k T_{e}}{m_{e}}}
-
-    :param float kTe: electron temperature (in eV)
-    """
-    kTe = kTe * constants.e * 1.e7  # eV to erg
-    _vTe = math.sqrt(kTe / ME)
-    return FloatUnit(_vTe, 'cm s^-1')
-
-
-def vTi(kTi, m_i, **kwargs):
-    """
-    ion thermal velocity (in cm/s)
-
-    .. math::
-
-        v_{T_{i}} = \sqrt{\\frac{k T_{i}}{m_{i}}}
-
-    :param float kTi: ion temperature (in eV)
-    :param float m_i: ion mass (in g)
-    """
-    kTi = kTi * constants.e * 1.e7 # eV to erg
-    _vTi = math.sqrt(kTi / m_i)
-    return FloatUnit(_vTi, 'cm s^-1')
 '''

--- a/bapsflib/plasma/core.py
+++ b/bapsflib/plasma/core.py
@@ -13,15 +13,17 @@
 # TODO: add collision frequencies
 # TODO: add mean-free-paths
 #
-"""Core plasma paramters in (cgs)."""
+"""Core plasma parameters in (cgs)."""
 
+import astropy.constants as const
+import astropy.units as u
 import math
 
 from scipy import constants
 
-pconst = constants.physical_constants
+#pconst = constants.physical_constants
 
-
+'''
 class FloatUnit(float):
     """Template class for floats with a unit attribute."""
 
@@ -66,295 +68,9 @@ class IntUnit(int):
     def unit(self):
         """units of constant"""
         return self._unit
-
-
-#: atomic mass unit (g)
-AMU = FloatUnit(1000.0 * constants.m_u, 'g')
-
-#: speed of light (cm/s)
-C = FloatUnit(100.0 * constants.c, 'cm s^-1')
-
-#: fundamental charge (statcoul)
-E = FloatUnit(4.8032e-10, 'statcoul')
-
-#: Boltzmann constant (erg/K)
-KB = FloatUnit(1.3807e-16, 'erg k^-1')
-
-#: electron mass (g)
-ME = FloatUnit(1000.0 * constants.m_e, 'g')
-
-#: proton mass (g)
-MP = FloatUnit(1000.0 * constants.m_p, 'g')
-
-
-# ---- frequency constants ----
-def fce(Bo, **kwargs):
-    """
-    electron-cyclotron frequency (Hz)
-
-    .. math::
-
-        f_{ce} = \\frac{\Omega_{ce}}{2 \pi}
-        = -\\frac{|e| B_{o}}{2 \pi m_{e} c}
-
-    :param float Bo: magnetic field (in Gauss)
-
-    .. note:: see function :func:`oce`
-    """
-    _fce = oce(Bo) / (2.0 * math.pi)
-    return FloatUnit(_fce, 'Hz')
-
-
-def fci(Bo, m_i, Z, **kwargs):
-    """
-    ion-cyclotron frequency (Hz)
-
-    .. math::
-
-        f_{ci} = \\frac{\Omega_{ci}}{2 \pi}
-        = \\frac{Z |e| B_{o}}{2 \pi m_{i} c}
-
-    :param float Bo: magnetic-field (in Gauss)
-    :param float m_i: ion-mass (in g)
-    :param int Z: charge number
-
-    .. note:: see function :func:`oci`
-    """
-    _fci = oci(Bo, m_i, Z) / (2.0 * constants.pi)
-    return FloatUnit(_fci, 'Hz')
-
-
-def fLH(Bo, m_i, n_i, Z, **kwargs):
-    """
-    Lower-Hybrid Resonance frequency (Hz)
-
-    .. math::
-        f_{LH} = \\frac{\omega_{LH}}{2 \pi}
-
-    :param float Bo: magnetic field (in Gauss)
-    :param float m_i: ion mass (in g)
-    :param float n_i: ion number density (in :math:`cm^{-3}`)
-    :param int Z: ion charge number
-
-    .. note:: for details see function :func:`oLH`
-    """
-    _fLH = oLH(Bo, m_i, n_i, Z) / (2.0 * math.pi)
-    return FloatUnit(_fLH, 'Hz')
-
-
-def fpe(n_e, **kwargs):
-    """
-    electron-plasma frequency (Hz)
-
-    .. math::
-
-        f_{pe} = \\frac{\omega_{pe}}{2 \pi}
-        = \sqrt{\\frac{n_{e} e^{2}}{\pi m_{e}}}
-
-    :param float n_e: electron number density (in :math:`cm^{-3}`)
-
-    .. note:: see function :func:`ope`
-    """
-    _fpe = ope(n_e) / (2.0 * math.pi)
-    return FloatUnit(_fpe, 'Hz')
-
-
-def fpi(m_i, n_i, Z, **kwargs):
-    """
-    ion-plasma frequency (Hz)
-
-    .. math::
-
-        f_{pi} = \\frac{\omega_{pi}}{2 \pi}
-        = \sqrt{\\frac{n_{i} (Z e)^{2}}{\pi m_{i}}}
-
-    :param float m_i: ion mass (in g)
-    :param float n_i: ion number density (in :math:`cm^{-3}`)
-    :param int Z: ion charge number
-
-    .. note:: see function :func:`opi`
-    """
-    _fpi = opi(m_i, n_i, Z) / (2.0 * math.pi)
-    return FloatUnit(_fpi, 'Hz')
-
-
-def fUH(Bo, n_e, **kwargs):
-    """
-    Upper-Hybrid Resonance frequency (Hz)
-
-    .. math::
-
-        f_{UH} = \\frac{\omega_{UH}}{2 \pi}
-
-    :param float Bo: magnetic field (in Gauss)
-    :param float n_e: electron number density (in :math:`cm^{-3}`)
-
-    .. note:: see function :func:`oUH`
-    """
-    _fUH = oUH(Bo, n_e) / (2.0 * math.pi)
-    return FloatUnit(_fUH, 'Hz')
-
-
-def oce(Bo, **kwargs):
-    """
-    electron-cyclotron frequency (rad/s)
-
-    .. math::
-
-        \Omega_{ce} = -\\frac{|e| B_{o}}{m_{e} c}
-
-    :param float Bo: magnetic-field (in Gauss)
-    """
-    _oce = (-E * Bo) / (ME * C)
-    return FloatUnit(_oce, 'rad s^-1')
-
-
-def oci(Bo, m_i, Z, **kwargs):
-    """
-    ion-cyclotron frequency (rads / s)
-
-    .. math::
-
-        \Omega_{ci} = \\frac{Z |e| B_{o}}{m_{i} c}
-
-    :param float Bo: magnetic-field (in Gauss)
-    :param float m_i: ion-mass (in g)
-    :param int Z: charge number
-    """
-    _oci = (Z * E * Bo) / (m_i * C)
-    return FloatUnit(_oci, 'rad s^-1')
-
-
-def oLH(Bo, m_i, n_i, Z, **kwargs):
-    """
-    Lower-Hybrid Resonance frequency (rad/s)
-
-    .. math::
-        \\frac{1}{\omega_{LH}^{2}}=
-        \\frac{1}{\Omega_{i}^{2}+\omega_{pi}^{2}}
-        + \\frac{1}{\\lvert \Omega_{e}\Omega_{i} \\rvert}
-
-    .. note::
-
-        This form is for a quasi-neutral plasma that satisfies
-
-        .. math::
-            \\frac{Z m_{e}}{m_{i}} \ll
-            1 - \\left(\\frac{V_{A}}{c}\\right)^{2}
-
-    :param float Bo: magnetic field (in Gauss)
-    :param float m_i: ion mass (in g)
-    :param float n_i: ion number density (in :math:`cm^{-3}`)
-    :param int Z: ion charge number
-    """
-    _args = {'Bo': Bo, 'm_i': m_i, 'n_i': n_i, 'Z': Z}
-    _opi = opi(**_args)
-    _oce = oce(**_args)
-    _oci = oci(**_args)
-    first_term = 1.0 / ((_oci ** 2) + (_opi ** 2))
-    second_term = 1.0 / math.fabs(_oce * _oci)
-    _olh = math.sqrt(1.0 / (first_term + second_term))
-    return FloatUnit(_olh, 'rad s^-1')
-
-
-def ope(n_e, **kwargs):
-    """
-    electron-plasma frequency (in rad/s)
-
-    .. math::
-
-        \omega_{pe}^{2} = \\frac{4 \pi n_{e} e^2}{m_{e}}
-
-    :param float n_e: electron number density (in :math:`cm^{-3}`)
-    """
-    _ope = math.sqrt(4 * math.pi * n_e * E * E / ME)
-    return FloatUnit(_ope, 'rad s^-1')
-
-
-def opi(m_i, n_i, Z, **kwargs):
-    """
-    ion-plasma frequency (in rad/s)
-
-    .. math::
-
-        \omega_{pi}^{2} = \\frac{4 \pi n_{i} (Z e)^{2}}{m_{i}}
-
-    :param float m_i: ion mass (in g)
-    :param float n_i: ion number density (in :math:`cm^{-3}`)
-    :param int Z: ion charge number
-    """
-    _opi = math.sqrt(4 * math.pi * n_i * (Z * E) * (Z * E) / m_i)
-    return FloatUnit(_opi, 'rad s^-1')
-
-
-def oUH(Bo, n_e, **kwargs):
-    """
-    Upper-Hybrid Resonance frequency (rad/s)
-
-    .. math::
-
-        \omega_{UH}^{2} =\omega_{pe}^{2} + \Omega_{ce}^{2}
-
-    :param float Bo: magnetic field (in Gauss)
-    :param float n_e: electron number density (in :math:`cm^{-3}`)
-    """
-    _ope = ope(n_e)
-    _oce = oce(Bo)
-    _ouh = math.sqrt((_ope ** 2) + (_oce ** 2))
-    return FloatUnit(_ouh, 'rad s^-1')
-
-
+'''
+'''
 # ---- length constants ----
-def lD(kT, n, **kwargs):
-    """
-    Debye Length (in cm)
-
-    .. math::
-
-        \lambda_{D} = \sqrt{\\frac{k_{B} T}{4 \pi n e^{2}}}
-
-    :param float kT: temperature (in eV)
-    :param float n: number density (in :math:`cm^{-3}`)
-    """
-    kT = kT * constants.e * 1.e7  # eV to ergs
-    _lD = math.sqrt(kT / (4.0 * math.pi * n)) / E
-    return FloatUnit(_lD, 'cm')
-
-
-def lpe(n_e, **kwargs):
-    """
-    electron-inertial length (cm)
-
-    .. math::
-
-        l_{pe} = \\frac{c}{\omega_{pe}}
-
-    :param float n_e: electron number density (in :math:`cm^{-3}`)
-
-    .. note:: see function :func:`ope`
-    """
-    _lpe = C / ope(n_e)
-    return FloatUnit(_lpe, 'cm')
-
-
-def lpi(m_i, n_i, Z, **kwargs):
-    """
-    ion-inertial length (cm)
-
-    .. math::
-
-        l_{pi} = \\frac{c}{\omega_{pi}}
-
-    :param float m_i: ion mass (in g)
-    :param float n_i: ion number density (in :math:`cm^{-3}`)
-    :param int Z: ion charge number
-
-    .. note:: see function :func:`opi`
-    """
-    _lpi = C / opi(m_i, n_i, Z)
-    return FloatUnit(_lpi, 'cm')
-
-
 def rce(Bo, kTe, **kwargs):
     """
     electron gyroradius (cm)
@@ -392,30 +108,6 @@ def rci(Bo, kTi, m_i, Z, **kwargs):
 
 
 # ---- velocity constants ----
-def cs(kTe, m_i, Z, gamma=1.0, **kwargs):
-    """
-    ion sound speed (cm/s)
-
-    .. math::
-
-        C_{s} = \sqrt{\\frac{\gamma Z k T_{e}}{m_{i}}}
-
-    .. note::
-
-        :math:`\gamma=1` for the case of :math:`T_{i}\ll T_{e}`
-        (DEFAULT)
-
-    :param float kTe: electron temperature (in eV)
-    :param float m_i: ion mass (in g)
-    :param int Z: charge number
-    :param float gamma: adiabatic index
-    """
-    # TODO: double check adiabatic index default value
-    kTe = kTe * constants.e * 1.e7 # eV to ergs
-    _cs = math.sqrt(gamma * Z * kTe / m_i)
-    return FloatUnit(_cs, 'cm s^-1')
-
-
 def VA(Bo, m_i, n_i, **kwargs):
     """
     Alfvén Velocity (in cm/s)
@@ -461,3 +153,4 @@ def vTi(kTi, m_i, **kwargs):
     kTi = kTi * constants.e * 1.e7 # eV to erg
     _vTi = math.sqrt(kTi / m_i)
     return FloatUnit(_vTi, 'cm s^-1')
+'''

--- a/bapsflib/plasma/parameters.py
+++ b/bapsflib/plasma/parameters.py
@@ -38,7 +38,8 @@ __all__ = ['cyclotron_frequency', 'oce', 'oci',
            'inertial_length', 'lpe', 'lpi',
            'Alfven_speed', 'VA',
            'ion_sound_speed', 'cs',
-           'thermal_speed', 'vTe', 'vTi']
+           'thermal_speed', 'vTe', 'vTi',
+           'beta']
 
 
 # ---- Frequencies                                                  ----
@@ -482,7 +483,8 @@ def Alfven_speed(B: u.Quantity, n_e: u.Quantity, m_i: u.Quantity,
         V_{A} &= \\frac{B}
                  {\\sqrt{4 \\pi (n_{i} m_{i} + n_{e} m_{e})}} \\
 
-              &= \\frac{B}{\\sqrt{4 \\pi n_{e} (\\frac{1}{Z}m_{i} + m_{e})}}
+              &= \\frac{B}
+                 {\\sqrt{4 \\pi n_{e} (\\frac{1}{Z}m_{i} + m_{e})}}
 
     :param B: magnetic field (in Gauss)
     :param n_e: electron number density (in :math:`cm^{3}`)
@@ -642,3 +644,33 @@ def vTi(kTi: u.Quantity, m_i: u.Quantity, **kwargs) -> u.Quantity:
     :param m_i: ion mass (in g)
     """
     return thermal_speed(kTi, m_i, **kwargs)
+
+
+# ---- Dimensionless                                                ----
+@utils.check_quantity({'n': {'units': u.cm ** -3,
+                             'can_be_negative': False},
+                       'kT': {'units': u.eV,
+                              'can_be_negative': False},
+                       'B': {'units': u.Gauss,
+                             'can_be_negative': False}})
+def beta(n: u.Quantity, kT: u.Quantity, B: u.Quantity,
+         **kwargs) -> u.Quantity:
+    """
+    plasma beta of particle species :math:`s`
+
+    .. math::
+
+        \\beta_{s} = \\frac{n_{s} k_{B} T_{s}}{B^{2} / (8 \\pi)}
+
+    :param n: particle number density (in :math:`cm^{-3}`)
+    :param kT: particle temperature (in eV)
+    :param B: magnetic field (in Gauss)
+    """
+    # ensure proper units
+    n = n.to(u.cm ** -3)
+    kT = kT.to(u.erg)
+    B = B.to(u.Gauss)
+
+    _TP = n * kT
+    _MP = B ** 2 / (8.0 * const.pi)
+    return (_TP.value / _MP.value) * u.dimensionless_unscaled

--- a/bapsflib/plasma/parameters.py
+++ b/bapsflib/plasma/parameters.py
@@ -196,6 +196,16 @@ def opi(n_i: u.Quantity, Z: Union[int, float], m_i: u.Quantity,
                                     **kwargs['kwargs'])
 
 
+def oUH(B: u.Quantity, n_e: u.Quantity,
+        to_Hz=False, **kwargs) -> u.Quantity:
+    """
+    Upper-Hybrid Resonance Frequency (rad/s)
+
+    [alias for :func:`upper_hybrid_frequency`]
+    """
+    return upper_hybrid_frequency(B, n_e, to_Hz=to_Hz, **kwargs)
+
+
 @utils.check_quantity({'n': {'units': u.cm ** -3,
                              "can_be_negative": False},
                        'q': {'units': u.statcoulomb,
@@ -231,3 +241,27 @@ def plasma_frequency_generic(
     else:
         _op = _op * (u.rad / u.s)
     return _op
+
+
+@utils.check_quantity({'B': {'units': u.gauss,
+                             'can_be_negative': False},
+                       'n_e': {'units': u.cm ** -3,
+                               'can_be_negative': False}})
+def upper_hybrid_frequency(B: u.Quantity, n_e: u.Quantity,
+                           to_Hz=False, **kwargs) -> u.Quantity:
+    """
+    Upper-Hybrid Resonance frequency (rad/s)
+
+    .. math::
+
+        \\omega_{UH}^{2} =\\omega_{pe}^{2} + \\Omega_{ce}^{2}
+
+    :param B: magnetic field (in Gauss)
+    :param n_e: electron number density (in :math:`cm^{-3}`)
+    :param to_Hz: :code:`False` (DEFAULT). Set to :code:`True` to
+        return frequency in Hz (i.e. divide by :math:`2 * \\pi`)
+    """
+    _oce = oce(B, to_Hz=to_Hz, **kwargs)
+    _ope = ope(n_e, to_Hz=to_Hz, **kwargs)
+    _ouh = np.sqrt((_ope ** 2) + (_oce ** 2))
+    return _ouh

--- a/bapsflib/plasma/parameters.py
+++ b/bapsflib/plasma/parameters.py
@@ -167,10 +167,10 @@ def ope(n_e: u.Quantity, **kwargs) -> u.Quantity:
 
     :param n_e: electron number density (in :math:`cm^{-3}`)
     :param kwargs:  supports any keywords used by
-        :func:`plasma_frequency_generic`
+        :func:`plasma_frequency`
     """
-    return plasma_frequency_generic(n_e, const.e_gauss, const.m_e.cgs,
-                                    **kwargs['kwargs'])
+    return plasma_frequency(n_e, const.e_gauss, const.m_e.cgs,
+                            **kwargs['kwargs'])
 
 
 @utils.check_quantity({'n_i': {'units': u.cm ** -3,
@@ -190,10 +190,10 @@ def opi(n_i: u.Quantity, Z: Union[int, float], m_i: u.Quantity,
     :param Z: charge number
     :param m_i: ion mass (in g)
     :param kwargs:  supports any keywords used by
-        :func:`plasma_frequency_generic`
+        :func:`plasma_frequency`
     """
-    return plasma_frequency_generic(n_i, Z * const.e_gauss, m_i,
-                                    **kwargs['kwargs'])
+    return plasma_frequency(n_i, Z * const.e_gauss, m_i,
+                            **kwargs['kwargs'])
 
 
 def oUH(B: u.Quantity, n_e: u.Quantity,
@@ -212,7 +212,7 @@ def oUH(B: u.Quantity, n_e: u.Quantity,
                              "can_be_negative": True},
                        'm': {'units': u.g,
                              "can_be_negative": False}})
-def plasma_frequency_generic(
+def plasma_frequency(
         n: u.Quantity, q: u.Quantity, m: u.Quantity,
         to_Hz=False, **kwargs) -> u.Quantity:
     """
@@ -287,7 +287,7 @@ def inertial_length(n: u.Quantity, q: u.Quantity, m: u.Quantity,
     :param q: particle charge (in statcoulomb)
     :param m: particle mass (in g)
     """
-    _op = plasma_frequency_generic(n, q, m, **kwargs)
+    _op = plasma_frequency(n, q, m, **kwargs)
     _l = (const.c.cgs.value / _op.value) * u.cm
     return _l
 

--- a/bapsflib/plasma/parameters.py
+++ b/bapsflib/plasma/parameters.py
@@ -35,7 +35,8 @@ __all__ = ['cyclotron_frequency', 'oce', 'oci',
            'Debye_length', 'lD',
            'inertial_length', 'lpe', 'lpi',
            'Alfven_speed', 'VA',
-           'ion_sound_speed', 'cs']
+           'ion_sound_speed', 'cs',
+           'thermal_speed', 'vTe', 'vTi']
 
 
 # ---- Frequencies                                                  ----
@@ -504,6 +505,32 @@ def ion_sound_speed(kTe: u.Quantity, m_i: u.Quantity,
     return _cs
 
 
+@utils.check_relativistic
+@utils.check_quantity({'kT': {'units': u.eV,
+                              'can_be_negative': False},
+                       'm': {'units': u.g,
+                             'can_be_negative': False}})
+def thermal_speed(kT: u.Quantity, m: u.Quantity,
+                  **kwargs) -> u.Quantity:
+    """
+    generalized thermal speed (in cm/s)
+
+    .. math::
+
+        v_{th} = \\sqrt{\\frac{k_{B} T}{m}}
+
+    :param kT: temperature (in eV)
+    :param m: particle mass (in g)
+    """
+    # ensure proper units
+    kT = kT.to(u.erg)
+    m = m.to(u.g)
+
+    # calculate
+    _v = np.sqrt(kT / m)
+    return _v.to(u.cm / u.s)
+
+
 def VA(B: u.Quantity, n_e: u.Quantity, m_i: u.Quantity,
        Z: Union[int, float] = None, **kwargs) -> u.Quantity:
     """
@@ -515,3 +542,30 @@ def VA(B: u.Quantity, n_e: u.Quantity, m_i: u.Quantity,
             kwargs[name] = val
 
     return Alfven_speed(B, n_e, m_i, **kwargs)
+
+
+def vTe(kTe: u.Quantity, **kwargs) -> u.Quantity:
+    """
+    electron thermal speed (in cm/s)
+
+    .. math::
+
+        v_{T_{e}} = \\sqrt{\\frac{k_{B} T_{e}}{m_{e}}}
+
+    :param kTe: electron temperature (in eV)
+    """
+    return thermal_speed(kTe, const.m_e, **kwargs)
+
+
+def vTi(kTi: u.Quantity, m_i: u.Quantity, **kwargs) -> u.Quantity:
+    """
+    ion thermal speed (in cm/s)
+
+    .. math::
+
+        v_{T_{i}} = \\sqrt{\\frac{k_{B} T_{i}}{m_{i}}}
+
+    :param kTi: ion temperature (in eV)
+    :param m_i: ion mass (in g)
+    """
+    return thermal_speed(kTi, m_i, **kwargs)

--- a/bapsflib/plasma/parameters.py
+++ b/bapsflib/plasma/parameters.py
@@ -1,0 +1,141 @@
+# This file is part of the bapsflib package, a Python toolkit for the
+# BaPSF group at UCLA.
+#
+# http://plasma.physics.ucla.edu/
+#
+# Copyright 2017-2018 Erik T. Everson and contributors
+#
+# License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
+#   license terms and contributor agreement.
+#
+# TODO: add plasma betas (electron, ion, and total)
+# TODO: add Coulomb Logarithm
+# TODO: add collision frequencies
+# TODO: add mean-free-paths
+#
+"""
+Plasma parameters
+
+All units are in Gaussian cgs except for temperature, which is
+expressed in eV. (same as the NRL Plasma Formulary)
+"""
+import astropy.units as u
+import numpy as np
+
+from . import constants as conts
+from plasmapy import utils
+from typing import Union
+
+
+# ---- Frequencies                                                  ----
+@utils.check_quantity({'q': {'units': u.statcoulomb,
+                             "can_be_negative": True},
+                       'B': {'units': u.Gauss,
+                             "can_be_negative": False},
+                       'm': {'units': u.g,
+                             "can_be_negative": False}})
+def cyclotron_frequency(q: u.Quantity, B: u.Quantity, m: u.Quantity,
+                        to_Hz=False, **kwargs) -> u.Quantity:
+    """
+    particle cyclotron frequency (rad/s)
+
+    .. math::
+
+        \\Omega_{c} = \\frac{q B}{m c}
+
+    :param q: particle charge (in statcoulomb)
+    :param B: magnetic-field (in Gauss)
+    :param m: particle mass (in grams)
+    :param to_Hz: :code:`False` (DEFAULT). Set to :code:`True` to
+        return frequency in Hz (i.e. divide by :math:`2 * \\pi`)
+    """
+    # ensure args have correct units
+    q = q.to(u.Fr)
+    B = B.to(u.gauss)
+    m = m.to(u.g)
+
+    # calculate
+    _oc = ((q.value * B.value) / (m.value * conts.c.cgs.value))
+    if to_Hz:
+        _oc = (_oc / (2.0 * conts.pi)) * u.Hz
+    else:
+        _oc = _oc * (u.rad / u.s)
+    return _oc
+
+
+@utils.check_quantity({'n': {'units': u.cm ** -3,
+                             "can_be_negative": False},
+                       'q': {'units': u.statcoulomb,
+                             "can_be_negative": True},
+                       'm': {'units': u.g,
+                             "can_be_negative": False}})
+def plasma_frequency_generic(
+        n: u.Quantity, q: u.Quantity, m: u.Quantity,
+        to_Hz=False, **kwargs) -> u.Quantity:
+    """
+    generalized plasma frequency (rad/s)
+
+    .. math::
+
+        \\omega_{p}^{2} = \\frac{4 \\pi n q^{2}}{m}
+
+    :param n: particle number density (in number/cm^3)
+    :param q: particle charge (in statcoulombs)
+    :param m: particle mass (in g)
+    :param to_Hz: :code:`False` (DEFAULT). Set to :code:`True` to
+        return frequency in Hz (i.e. divide by :math:`2 * \\pi`)
+    """
+    # ensure args have correct units
+    n = n.to(u.cm ** -3)
+    q = q.to(u.Fr)
+    m = m.to(u.g)
+
+    # calculate
+    _op = np.sqrt((4.0 * conts.pi * n.value * (q.value * q.value))
+                  / m.value)
+    if to_Hz:
+        _op = (_op / (2.0 * conts.pi)) * u.Hz
+    else:
+        _op = _op * (u.rad / u.s)
+    return _op
+
+
+@utils.check_quantity({'B': {'units': u.Gauss,
+                             "can_be_negative": False}})
+def oce(B: u.Quantity, **kwargs) -> u.Quantity:
+    """
+    electron-cyclotron frequency (rad/s)
+
+    .. math::
+
+        \\Omega_{ce} = -\\frac{|e| B}{m_{e} c}
+
+    :param B: magnetic-field (in Gauss)
+    :param kwargs: supports any keywords used by
+        :func:`cyclotron_frequency`
+    """
+    return cyclotron_frequency(-conts.e_gauss, B, conts.m_e,
+                               **kwargs['kwargs'])
+
+
+@utils.check_quantity({'B': {'units': u.Gauss,
+                             "can_be_negative": False},
+                       'm_i': {'units': u.g,
+                               "can_be_negative": False}})
+def oci(Z: Union[int, float], B: u.Quantity, m_i: u.Quantity,
+        **kwargs) -> u.Quantity:
+    """
+    ion-cyclotron frequency (rad/s)
+
+    .. math::
+
+        \\Omega_{ci} = \\frac{Z |e| B}{m_{i} c}
+
+    :param Z: charge number
+    :param B: magnetic-field (in Gauss)
+    :param m_i: ion mass (in grams)
+    :param kwargs: supports any keywords used by
+        :func:`cyclotron_frequency`
+    """
+    return cyclotron_frequency(Z * conts.e_gauss, B, m_i,
+                               **kwargs['kwargs'])

--- a/bapsflib/plasma/parameters.py
+++ b/bapsflib/plasma/parameters.py
@@ -148,8 +148,7 @@ def oLH(B: u.Quantity, n_i: u.Quantity,
         m_i: u.Quantity, Z: Union[int, float],
         to_Hz=False, **kwargs) -> u.Quantity:
     """
-    Lower-Hybrid resonance frequency (rad/s)
-
+    Lower-Hybrid resonance frequency (rad/s) --
     [alias for :func:`lower_hybrid_frequency`]
     """
     return lower_hybrid_frequency(B, m_i, n_i, Z, to_Hz=to_Hz, **kwargs)
@@ -199,8 +198,7 @@ def opi(n_i: u.Quantity, Z: Union[int, float], m_i: u.Quantity,
 def oUH(B: u.Quantity, n_e: u.Quantity,
         to_Hz=False, **kwargs) -> u.Quantity:
     """
-    Upper-Hybrid resonance frequency (rad/s)
-
+    Upper-Hybrid resonance frequency (rad/s) --
     [alias for :func:`upper_hybrid_frequency`]
     """
     return upper_hybrid_frequency(B, n_e, to_Hz=to_Hz, **kwargs)

--- a/bapsflib/plasma/parameters.py
+++ b/bapsflib/plasma/parameters.py
@@ -22,7 +22,7 @@ expressed in eV. (same as the NRL Plasma Formulary)
 import astropy.units as u
 import numpy as np
 
-from . import constants as conts
+from . import constants as const
 from plasmapy import utils
 from typing import Union
 
@@ -55,12 +55,94 @@ def cyclotron_frequency(q: u.Quantity, B: u.Quantity, m: u.Quantity,
     m = m.to(u.g)
 
     # calculate
-    _oc = ((q.value * B.value) / (m.value * conts.c.cgs.value))
+    _oc = ((q.value * B.value) / (m.value * const.c.cgs.value))
     if to_Hz:
-        _oc = (_oc / (2.0 * conts.pi)) * u.Hz
+        _oc = (_oc / (2.0 * const.pi)) * u.Hz
     else:
         _oc = _oc * (u.rad / u.s)
     return _oc
+
+
+@utils.check_quantity({'B': {'units': u.Gauss,
+                             "can_be_negative": False}})
+def oce(B: u.Quantity, **kwargs) -> u.Quantity:
+    """
+    electron-cyclotron frequency (rad/s)
+
+    .. math::
+
+        \\Omega_{ce} = -\\frac{|e| B}{m_{e} c}
+
+    :param B: magnetic-field (in Gauss)
+    :param kwargs: supports any keywords used by
+        :func:`cyclotron_frequency`
+    """
+    return cyclotron_frequency(-const.e_gauss, B, const.m_e,
+                               **kwargs['kwargs'])
+
+
+@utils.check_quantity({'B': {'units': u.Gauss,
+                             "can_be_negative": False},
+                       'm_i': {'units': u.g,
+                               "can_be_negative": False}})
+def oci(Z: Union[int, float], B: u.Quantity, m_i: u.Quantity,
+        **kwargs) -> u.Quantity:
+    """
+    ion-cyclotron frequency (rad/s)
+
+    .. math::
+
+        \\Omega_{ci} = \\frac{Z |e| B}{m_{i} c}
+
+    :param Z: charge number
+    :param B: magnetic-field (in Gauss)
+    :param m_i: ion mass (in grams)
+    :param kwargs: supports any keywords used by
+        :func:`cyclotron_frequency`
+    """
+    return cyclotron_frequency(Z * const.e_gauss, B, m_i,
+                               **kwargs['kwargs'])
+
+
+@utils.check_quantity({'n_e': {'units': u.cm ** -3,
+                               'can_be_negative': False}})
+def ope(n_e: u.Quantity, **kwargs) -> u.Quantity:
+    """
+    electron-plasma frequency (in rad/s)
+
+    .. math::
+
+        \\omega_{pe}^{2} = \\frac{4 \\pi n_{e} e^{2}}{m_e}
+
+    :param n_e: electron number density (in number/cm^3)
+    :param kwargs:  supports any keywords used by
+        :func:`plasma_frequency_generic`
+    """
+    return plasma_frequency_generic(n_e, const.e_gauss, const.m_e,
+                                    **kwargs['kwargs'])
+
+
+@utils.check_quantity({'n_i': {'units': u.cm ** -3,
+                               'can_be_negative': False},
+                       'm_i': {'units': u.g,
+                               'can_be_negative': False}})
+def opi(n_i: u.Quantity, Z: Union[int, float], m_i: u.Quantity,
+        **kwargs) -> u.Quantity:
+    """
+    ion-plasma frequency (in rad/s)
+
+    .. math::
+
+        \\omega_{pi}^{2} = \\frac{4 \\pi n_{i} (Z e)^{2}}{m_i}
+
+    :param n_i: ion number density (in number/cm^3)
+    :param Z: charge number
+    :param m_i: ion mass (in g)
+    :param kwargs:  supports any keywords used by
+        :func:`plasma_frequency_generic`
+    """
+    return plasma_frequency_generic(n_i, Z * const.e_gauss, m_i,
+                                    **kwargs['kwargs'])
 
 
 @utils.check_quantity({'n': {'units': u.cm ** -3,
@@ -91,51 +173,10 @@ def plasma_frequency_generic(
     m = m.to(u.g)
 
     # calculate
-    _op = np.sqrt((4.0 * conts.pi * n.value * (q.value * q.value))
+    _op = np.sqrt((4.0 * const.pi * n.value * (q.value * q.value))
                   / m.value)
     if to_Hz:
-        _op = (_op / (2.0 * conts.pi)) * u.Hz
+        _op = (_op / (2.0 * const.pi)) * u.Hz
     else:
         _op = _op * (u.rad / u.s)
     return _op
-
-
-@utils.check_quantity({'B': {'units': u.Gauss,
-                             "can_be_negative": False}})
-def oce(B: u.Quantity, **kwargs) -> u.Quantity:
-    """
-    electron-cyclotron frequency (rad/s)
-
-    .. math::
-
-        \\Omega_{ce} = -\\frac{|e| B}{m_{e} c}
-
-    :param B: magnetic-field (in Gauss)
-    :param kwargs: supports any keywords used by
-        :func:`cyclotron_frequency`
-    """
-    return cyclotron_frequency(-conts.e_gauss, B, conts.m_e,
-                               **kwargs['kwargs'])
-
-
-@utils.check_quantity({'B': {'units': u.Gauss,
-                             "can_be_negative": False},
-                       'm_i': {'units': u.g,
-                               "can_be_negative": False}})
-def oci(Z: Union[int, float], B: u.Quantity, m_i: u.Quantity,
-        **kwargs) -> u.Quantity:
-    """
-    ion-cyclotron frequency (rad/s)
-
-    .. math::
-
-        \\Omega_{ci} = \\frac{Z |e| B}{m_{i} c}
-
-    :param Z: charge number
-    :param B: magnetic-field (in Gauss)
-    :param m_i: ion mass (in grams)
-    :param kwargs: supports any keywords used by
-        :func:`cyclotron_frequency`
-    """
-    return cyclotron_frequency(Z * conts.e_gauss, B, m_i,
-                               **kwargs['kwargs'])

--- a/bapsflib/plasma/parameters.py
+++ b/bapsflib/plasma/parameters.py
@@ -122,8 +122,7 @@ def lower_hybrid_frequency(B: u.Quantity, n_i: u.Quantity,
     _olh = np.sqrt(1.0 / (first_term + second_term))
     return _olh
 
-@utils.check_quantity({'B': {'units': u.Gauss,
-                             "can_be_negative": False}})
+
 def oce(B: u.Quantity, **kwargs) -> u.Quantity:
     """
     electron-cyclotron frequency (rad/s)
@@ -140,10 +139,6 @@ def oce(B: u.Quantity, **kwargs) -> u.Quantity:
                                **kwargs['kwargs'])
 
 
-@utils.check_quantity({'B': {'units': u.Gauss,
-                             "can_be_negative": False},
-                       'm_i': {'units': u.g,
-                               "can_be_negative": False}})
 def oci(B: u.Quantity, m_i: u.Quantity, Z: Union[int, float] = 1,
         **kwargs) -> u.Quantity:
     """
@@ -185,8 +180,6 @@ def oLH(B: u.Quantity, n_i: u.Quantity, m_i: u.Quantity,
     return lower_hybrid_frequency(B, m_i, n_i, **kwargs)
 
 
-@utils.check_quantity({'n_e': {'units': u.cm ** -3,
-                               'can_be_negative': False}})
 def ope(n_e: u.Quantity, **kwargs) -> u.Quantity:
     """
     electron-plasma frequency (in rad/s)
@@ -203,10 +196,6 @@ def ope(n_e: u.Quantity, **kwargs) -> u.Quantity:
                             **kwargs['kwargs'])
 
 
-@utils.check_quantity({'n_i': {'units': u.cm ** -3,
-                               'can_be_negative': False},
-                       'm_i': {'units': u.g,
-                               'can_be_negative': False}})
 def opi(n_i: u.Quantity, m_i: u.Quantity,
         Z: Union[int, float] = 1, **kwargs) -> u.Quantity:
     """
@@ -365,8 +354,6 @@ def lD(kTe: u.Quantity, n: u.Quantity, **kwargs) -> u.Quantity:
     return Debye_length(kTe, n, **kwargs)
 
 
-@utils.check_quantity({'n_e': {'units': u.cm ** -3,
-                               'can_be_negative': False}})
 def lpe(n_e: u.Quantity, **kwargs) -> u.Quantity:
     """
     electron-inertial length (cm)
@@ -380,10 +367,6 @@ def lpe(n_e: u.Quantity, **kwargs) -> u.Quantity:
     return inertial_length(n_e, -const.e_gauss, const.m_e, **kwargs)
 
 
-@utils.check_quantity({'n_i': {'units': u.cm ** -3,
-                               'can_be_negative': False},
-                       'm_i': {'units': u.g,
-                               'can_be_negative': False}})
 def lpi(n_i: u.Quantity, m_i: u.Quantity,
         Z: Union[int, float] = 1, **kwargs) -> u.Quantity:
     """
@@ -408,7 +391,7 @@ def lpi(n_i: u.Quantity, m_i: u.Quantity,
 
 
 # ---- Velocities                                                   ----
-#@utils.check_relativistic
+@utils.check_relativistic
 @utils.check_quantity({'B': {'units': u.gauss,
                              'can_be_negative': False},
                        'n_e': {'units': u.cm ** -3,

--- a/bapsflib/plasma/parameters.py
+++ b/bapsflib/plasma/parameters.py
@@ -266,6 +266,29 @@ def upper_hybrid_frequency(B: u.Quantity, n_e: u.Quantity,
 
 
 # ---- Lengths                                                      ----
+@utils.check_quantity({'kTe': {'units': u.eV,
+                               'can_be_negative': False},
+                       'n': {'units': u.cm ** -3,
+                             'can_be_negative': False}})
+def Debye_length(kTe: u.Quantity, n: u.Quantity,
+                 **kwargs) -> u.Quantity:
+    """
+    Debye length (in cm)
+
+    .. math::
+
+        \\lambda_{D} = \\sqrt{\\frac{k_{B} T_{e}}{4 \\pi n e^{2}}}
+
+    :param kTe: electron temperature (in eV)
+    :param n: number density (in :math:`cm^{-3}`)
+    """
+    # ensure args have correct units
+    kTe = kTe.to(u.erg)
+    n = n.to(u.cm ** -3)
+    _lD = np.sqrt(kTe / (4.0 * const.pi * n * (const.e_gauss ** 2)))
+    return _lD.cgs
+
+
 @utils.check_quantity({'n': {'units': u.cm ** -3,
                              'can_be_negative': False},
                        'q': {'units': u.statcoulomb,
@@ -288,6 +311,13 @@ def inertial_length(n: u.Quantity, q: u.Quantity, m: u.Quantity,
     _op = plasma_frequency(n, q, m, **kwargs)
     _l = (const.c.cgs.value / _op.value) * u.cm
     return _l
+
+
+def lD(kTe: u.Quantity, n: u.Quantity, **kwargs) -> u.Quantity:
+    """
+    Debye length (in cm) -- [alias for :func:`Debye_length`]
+    """
+    return Debye_length(kTe, n, **kwargs)
 
 
 @utils.check_quantity({'n_e': {'units': u.cm ** -3,

--- a/bapsflib/plasma/parameters.py
+++ b/bapsflib/plasma/parameters.py
@@ -23,6 +23,7 @@ import astropy.units as u
 import numpy as np
 
 from . import constants as const
+from bapsflib.utils.errors import PhysicsError
 from plasmapy import utils
 from typing import Union
 

--- a/bapsflib/utils/__init__.py
+++ b/bapsflib/utils/__init__.py
@@ -9,5 +9,13 @@
 #   license terms and contributor agreement.
 #
 from . import (errors, warnings)
+from astropy.constants import Constant
 
-__all__ = ['errors', 'warnings']
+__all__ = ['BaPSFConstant', 'errors', 'warnings']
+
+
+class BaPSFConstant(Constant):
+    """Factory Class for BaPSF Constants"""
+    default_reference = 'Basic Plasma Facility'
+    _registry = {}
+    _has_incompatible_units = set()

--- a/bapsflib/utils/errors.py
+++ b/bapsflib/utils/errors.py
@@ -34,3 +34,8 @@ class HDFReadControlError(HDFReadError):
 class HDFReadMSIError(HDFReadError):
     """Exception for failed HDF5 reading of digitizer."""
     pass
+
+
+class PhysicsError(Exception):
+    """Exception for physics errors."""
+    pass

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python3 -msphinx
+SPHINXBUILD   = python3 -m sphinx
 SPHINXPROJ    = bapsflib
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -5,7 +5,7 @@ pushd %~dp0
 REM Command file for Sphinx documentation
 
 if "%SPHINXBUILD%" == "" (
-	set SPHINXBUILD=python -msphinx
+	set SPHINXBUILD=python3 -m sphinx
 )
 set SOURCEDIR=.
 set BUILDDIR=_build

--- a/docs/src/bapsflib.lapd.constants.constants.rst
+++ b/docs/src/bapsflib.lapd.constants.constants.rst
@@ -11,7 +11,7 @@ bapsflib\.lapd\.constants\.constants
     .. autosummary::
         :nosignatures:
 
-        BaPSFConstant
+        LaPDConstant
         SouthCathode
 
     .. rubric:: Constants

--- a/docs/src/bapsflib.plasma.constants.rst
+++ b/docs/src/bapsflib.plasma.constants.rst
@@ -1,0 +1,16 @@
+bapsflib\.plasma\.\constants
+============================
+.. py:currentmodule:: bapsflib.plasma.constants
+
+.. automodule:: bapsflib.plasma.constants
+
+.. .. rubric:: Constants
+
+.. .. autosummary::
+    :nosignatures:
+
+..    port_spacing
+    ref_port
+
+.. .. autodata:: port_spacing
+.. .. autodata:: ref_port

--- a/docs/src/bapsflib.plasma.parameters.rst
+++ b/docs/src/bapsflib.plasma.parameters.rst
@@ -12,8 +12,10 @@ bapsflib\.plasma\.parameters
         :nosignatures:
 
         cyclotron_frequency
+        lower_hybrid_frequency
         oce
         oci
+        oLH
         ope
         opi
         plasma_frequency_generic

--- a/docs/src/bapsflib.plasma.parameters.rst
+++ b/docs/src/bapsflib.plasma.parameters.rst
@@ -16,7 +16,7 @@ bapsflib\.plasma\.parameters
         oci
         lower_hybrid_frequency
         oLH
-        plasma_frequency_generic
+        plasma_frequency
         ope
         opi
         upper_hybrid_frequency

--- a/docs/src/bapsflib.plasma.parameters.rst
+++ b/docs/src/bapsflib.plasma.parameters.rst
@@ -48,3 +48,10 @@ bapsflib\.plasma\.parameters
         thermal_speed
         vTe
         vTi
+
+    .. rubric:: Dimensionless
+
+    .. autosummary::
+        :nosignatures:
+
+        beta

--- a/docs/src/bapsflib.plasma.parameters.rst
+++ b/docs/src/bapsflib.plasma.parameters.rst
@@ -14,3 +14,6 @@ bapsflib\.plasma\.parameters
         cyclotron_frequency
         oce
         oci
+        ope
+        opi
+        plasma_frequency_generic

--- a/docs/src/bapsflib.plasma.parameters.rst
+++ b/docs/src/bapsflib.plasma.parameters.rst
@@ -1,0 +1,16 @@
+bapsflib\.plasma\.parameters
+============================
+
+.. automodule:: bapsflib.plasma.parameters
+    :show-inheritance:
+    :members:
+    :undoc-members:
+
+    .. rubric:: Functions
+
+    .. autosummary::
+        :nosignatures:
+
+        cyclotron_frequency
+        oce
+        oci

--- a/docs/src/bapsflib.plasma.parameters.rst
+++ b/docs/src/bapsflib.plasma.parameters.rst
@@ -38,5 +38,7 @@ bapsflib\.plasma\.parameters
     .. autosummary::
         :nosignatures:
 
+        Alfven_speed
+        VA
         ion_sound_speed
         cs

--- a/docs/src/bapsflib.plasma.parameters.rst
+++ b/docs/src/bapsflib.plasma.parameters.rst
@@ -6,16 +6,18 @@ bapsflib\.plasma\.parameters
     :members:
     :undoc-members:
 
-    .. rubric:: Functions
+    .. rubric:: Frequencies
 
     .. autosummary::
         :nosignatures:
 
         cyclotron_frequency
-        lower_hybrid_frequency
         oce
         oci
+        lower_hybrid_frequency
         oLH
+        plasma_frequency_generic
         ope
         opi
-        plasma_frequency_generic
+        upper_hybrid_frequency
+        oUH

--- a/docs/src/bapsflib.plasma.parameters.rst
+++ b/docs/src/bapsflib.plasma.parameters.rst
@@ -42,3 +42,6 @@ bapsflib\.plasma\.parameters
         VA
         ion_sound_speed
         cs
+        thermal_speed
+        vTe
+        vTi

--- a/docs/src/bapsflib.plasma.parameters.rst
+++ b/docs/src/bapsflib.plasma.parameters.rst
@@ -32,3 +32,11 @@ bapsflib\.plasma\.parameters
         inertial_length
         lpe
         lpi
+
+    .. rubric:: Velocities
+
+    .. autosummary::
+        :nosignatures:
+
+        ion_sound_speed
+        cs

--- a/docs/src/bapsflib.plasma.parameters.rst
+++ b/docs/src/bapsflib.plasma.parameters.rst
@@ -27,6 +27,8 @@ bapsflib\.plasma\.parameters
     .. autosummary::
         :nosignatures:
 
+        Debye_length
+        lD
         inertial_length
         lpe
         lpi

--- a/docs/src/bapsflib.plasma.parameters.rst
+++ b/docs/src/bapsflib.plasma.parameters.rst
@@ -27,6 +27,9 @@ bapsflib\.plasma\.parameters
     .. autosummary::
         :nosignatures:
 
+        cyclotron_radius
+        rce
+        rci
         Debye_length
         lD
         inertial_length

--- a/docs/src/bapsflib.plasma.parameters.rst
+++ b/docs/src/bapsflib.plasma.parameters.rst
@@ -21,3 +21,12 @@ bapsflib\.plasma\.parameters
         opi
         upper_hybrid_frequency
         oUH
+
+    .. rubric:: Lengths
+
+    .. autosummary::
+        :nosignatures:
+
+        inertial_length
+        lpe
+        lpi

--- a/docs/src/bapsflib.plasma.rst
+++ b/docs/src/bapsflib.plasma.rst
@@ -1,33 +1,28 @@
 bapsflib\.plasma
-=================
+================
 
 .. warning:: Package Currently Under Development
 
 .. automodule:: bapsflib.plasma
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-Subpackages
------------
 
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 2
+    :titlesonly:
+    :caption: Sub-Packages & Modules
 
+    bapsflib.plasma.constants
+    bapsflib.plasma.parameters
 
-Modules
--------
+.. bapsflib.plasma.plasma
 
-.. contents::
-    :depth: 2
-    :local:
+.. .. rubric:: Classes
 
-bapsflib\.plasma\.core
-^^^^^^^^^^^^^^^^^^^^^^
+.. .. autosummary:: bapsflib.Plasma.SimplePlasma
+    :nosignatures:
 
-.. automodule:: bapsflib.plasma.core
+.. .. autoclass:: bapsflib.lapd.SimplePlasma
     :members:
     :undoc-members:
-    :special-members:
-    :exclude-members: __dict__, __init__, __module__, __weakref__
     :show-inheritance:
+    :inherited-members:
+    :exclude-members:

--- a/docs/src/bapsflib.rst
+++ b/docs/src/bapsflib.rst
@@ -13,5 +13,4 @@ bapsflib
 
     ./bapsflib._hdf
     ./bapsflib.lapd
-
-.. ./bapsflib.plasma
+    ./bapsflib.plasma

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ codecov >= 2.0.15
 coverage >= 4.5.1
 h5py >= 2.6
 numpy >= 1.12
+plasmapy >= 0.1.0
 scipy >= 1.0.0
 #
 # Add Sphinx/Documentation requirements


### PR DESCRIPTION
Creating two new sub-modules:

1. [`bapsflib.plasma.constants`](https://github.com/BaPSF/bapsflib/blob/add_astropy_units_to_plasma/bapsflib/plasma/constants.py)

    * module focuses on providing a number of physical constants
    * all constants are provided as an `astropy.constants.Constant`
    * current [`constants` documentation](https://bapsflib.readthedocs.io/en/add_astropy_units_to_plasma/src/bapsflib.plasma.constants.html)

1. [`bapsflib.plasma.parameters`](https://github.com/BaPSF/bapsflib/blob/add_astropy_units_to_plasma/bapsflib/plasma/parameters.py)

    * module focuses on providing a number of plasma parameters
    * functionality of parameters is designed to be useful with values and units typically acquired during experiments
    * Units follow the NRL Plasma Formulary.  All units are in Gaussian cgs except for temperature, which is expressed in eV.
    * all parameters are returned as `astropy.units.Quantity`
    * current [`parameters` documentation](https://bapsflib.readthedocs.io/en/add_astropy_units_to_plasma/src/bapsflib.plasma.parameters.html)

### Tasks before merge:
* **`bapsflib.plasma.constants`**
    - [ ] Review and add all desired physical constants
    - [ ] Agree on naming for all constants
    - [ ] All constants must be `astropy.constants.Constant`
    - [ ] Cover with tests
* **`bapsflib.plasma.constants`**
    - [ ] Review and add all desired plasma paramters
    - [ ] Agree on naming for all parameters
    - [ ] Parameter functionality is consistent and suit to how plasma values are measured/calculated in the lab environment
    - [ ] All constants must be `astropy.units.Quantity`
    - [ ] Units follow the NRL Plasma Formulary scheme
    - [ ] Cover with tests
