### PR TITLE
Allow `condition_shotnum()` to handle single element numpy arrays

### DIFF
--- a/bapsflib/_hdf/utils/helpers.py
+++ b/bapsflib/_hdf/utils/helpers.py
@@ -561,7 +561,8 @@ def condition_shotnum(shotnum: Any,
                              'array would be NULL')
 
     elif isinstance(shotnum, np.ndarray):
-        shotnum = shotnum.squeeze()
+        if shotnum.ndim != 1:
+            shotnum = shotnum.squeeze()
         if shotnum.ndim != 1 \
                 or not np.issubdtype(shotnum.dtype, np.integer) \
                 or bool(shotnum.dtype.names):

--- a/bapsflib/_hdf/utils/tests/test_helpers.py
+++ b/bapsflib/_hdf/utils/tests/test_helpers.py
@@ -663,6 +663,8 @@ class TestConditionShotnum(TestBase):
 
         # shotnum valid
         sn = [
+            (np.array([12], np.int32),
+             np.array([12], np.uint32)),
             (np.array([-5, 0, 10], np.int32),
              np.array([10], np.uint32)),
             (np.array([20, 30], np.int32),


### PR DESCRIPTION
Update function `condition_shotnum()` so single element `numpy` arrays do not raise a `ValueError` (see issue #35 for details)

closes #35 