### PR TITLE
Merge v1.0.1

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,7 +4,7 @@ branch = true
 omit =
     # omit all test files
     */tests/*
-    # omit documentaiton files
+    # omit documentation files
     docs/
     # omit license files
     LICENSES/
@@ -14,6 +14,12 @@ omit =
 [report]
 # Regexes for lines to exclude from consideration
 exclude_lines =
+    # Re-enable pragma's:
     pragma: no cover
+    pragma: no branch
+
+    # Do not complain if test do not hit defensive assertion code:
     raise NotImplementedError
+
+    # Do not complain if non-runnable code is not run"
     if __name__ = .__main__.:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/bapsflib.svg)](https://pypi.org/project/bapsflib)
 [![License](https://img.shields.io/badge/License-BSD-blue.svg)](./LICENSES/LICENSE.txt)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/bapsflib.svg)](https://pypi.org/project/bapsflib)
 
 [![Documentation Status](https://readthedocs.org/projects/bapsflib/badge/)](https://bapsflib.readthedocs.io/en/latest)
 [![Build Status](https://img.shields.io/travis/BaPSF/bapsflib/master.svg?label=Travis%20CI)](https://travis-ci.org/BaPSF/bapsflib)

--- a/bapsflib/__init__.py
+++ b/bapsflib/__init__.py
@@ -26,4 +26,4 @@ from . import lapd
 from . import plasma
 
 # --- Define version ---------------------------------------------------
-__version__ = '1.0.1.dev'
+__version__ = '1.0.1'

--- a/bapsflib/_hdf/__init__.py
+++ b/bapsflib/_hdf/__init__.py
@@ -13,7 +13,7 @@ This package contains the mapping classes (in :mod:`~.maps`) and file
 access classes (in :mod:`~.utils`) used to map and interface with the
 HDF5 files generated at BaPSF.
 """
+__all__ = ['ConType', 'File', 'HDFMap']
+
 from .maps import (ConType, HDFMap)
 from .utils.file import File
-
-__all__ = ['ConType', 'File', 'HDFMap']

--- a/bapsflib/_hdf/maps/__init__.py
+++ b/bapsflib/_hdf/maps/__init__.py
@@ -19,12 +19,12 @@ mapping :ibf:`Digitizer` HDF5 groups, and
 :mod:`~.msi` contains routines for mapping
 :ibf:`MSI Diagnostic` HDF5 groups.
 """
+__all__ = ['ConType', 'FauxHDFBuilder', 'hdfmap', 'HDFMap',
+           'HDFMapControls', 'HDFMapDigitizers', 'HDFMapMSI']
+
 from . import hdfmap
 from .controls import (ConType, HDFMapControls)
 from .digitizers import HDFMapDigitizers
 from .hdfmap import HDFMap
 from .msi import HDFMapMSI
 from .tests.fauxhdfbuilder import FauxHDFBuilder
-
-__all__ = ['ConType', 'FauxHDFBuilder', 'hdfmap', 'HDFMap',
-           'HDFMapControls', 'HDFMapDigitizers', 'HDFMapMSI']

--- a/bapsflib/_hdf/maps/digitizers/__init__.py
+++ b/bapsflib/_hdf/maps/digitizers/__init__.py
@@ -12,8 +12,8 @@
 Package of digitizer mapping classes and their constructor
 (:class:`~.map_digis.HDFMapDigitizers`).
 """
-from . import (map_digis, sis3301, siscrate, templates)
-from .map_digis import HDFMapDigitizers
-
 __all__ = ['HDFMapDigitizers', 'map_digis', 'sis3301', 'siscrate',
            'templates']
+
+from . import (map_digis, sis3301, siscrate, templates)
+from .map_digis import HDFMapDigitizers

--- a/bapsflib/_hdf/maps/msi/__init__.py
+++ b/bapsflib/_hdf/maps/msi/__init__.py
@@ -12,10 +12,10 @@
 Package of MSI diagnostic mapping classes and their constructor
 (:class:`~.map_msi.HDFMapMSI`).
 """
-from . import (discharge, gaspressure, heater, interferometerarray,
-               magneticfield, map_msi, templates)
-from .map_msi import HDFMapMSI
-
 __all__ = ['discharge', 'gaspressure', 'heater', 'HDFMapMSI',
            'interferometerarray', 'magneticfield', 'map_msi',
            'templates']
+
+from . import (discharge, gaspressure, heater, interferometerarray,
+               magneticfield, map_msi, templates)
+from .map_msi import HDFMapMSI

--- a/bapsflib/_hdf/utils/__init__.py
+++ b/bapsflib/_hdf/utils/__init__.py
@@ -12,8 +12,8 @@
 This package contains an assortment of utility classes used to
 access and interface with the HDF5 files generated at BaPSF.
 """
+__all__ = ['file', 'hdfoverview', 'hdfreadcontrols', 'hdfreaddata',
+           'hdfreadmsi', 'helpers']
+
 from . import (file, hdfoverview, hdfreadcontrols, hdfreaddata,
                hdfreadmsi, helpers)
-
-__all__ = ['file', 'hdfoverview', 'hdfreadcontrols.py', 'hdfreaddata',
-           'hdfreadmsi', 'helpers']

--- a/bapsflib/_hdf/utils/tests/__init__.py
+++ b/bapsflib/_hdf/utils/tests/__init__.py
@@ -35,3 +35,19 @@ class TestBase(ut.TestCase):
         # cleanup and close HDF5 file
         super().tearDownClass()
         cls.f.cleanup()
+
+    @property
+    def filename(self) -> str:
+        return self.f.filename
+
+    @property
+    def control_path(self) -> str:
+        return 'Raw data + config'
+
+    @property
+    def digitizer_path(self) -> str:
+        return 'Raw data + config'
+
+    @property
+    def msi_path(self) -> str:
+        return 'MSI'

--- a/bapsflib/_hdf/utils/tests/__init__.py
+++ b/bapsflib/_hdf/utils/tests/__init__.py
@@ -8,28 +8,12 @@
 # License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
 #   license terms and contributor agreement.
 #
+__all__ = ['TestBase', 'with_bf']
+
 import unittest as ut
 
 from bapsflib._hdf.maps import FauxHDFBuilder
-from functools import wraps
-
-from ..file import File
-
-
-def with_bf(func):
-    """
-    Context decorator for managing the opening and closing BaPSF HDF5
-    Files :class:`bapsflib._hdf.utils.file.File`.  Intended for use on
-    test methods.
-    """
-    @wraps(func)
-    def wrapper(self, *args, **kwargs):
-        with File(self.f.filename,
-                  control_path='Raw data + config',
-                  digitizer_path='Raw data + config',
-                  msi_path='MSI') as bf:
-            return func(self, bf, *args, **kwargs)
-    return wrapper
+from bapsflib.utils.decorators import with_bf
 
 
 class TestBase(ut.TestCase):

--- a/bapsflib/lapd/__init__.py
+++ b/bapsflib/lapd/__init__.py
@@ -18,9 +18,9 @@ diameters, port spacing, etc.).  The :mod:`~bapsflib.lapd.tools` package
 contains functions and classes relevant for calculating LaPD parameters
 (e.g. converting port number to axial z location, etc.).
 """
+__all__ = ['_hdf', 'constants', 'File', 'tools']
+
 from . import _hdf
 from . import constants
 from . import tools
 from ._hdf.file import File
-
-__all__ = ['_hdf', 'constants', 'File', 'tools']

--- a/bapsflib/lapd/_hdf/__init__.py
+++ b/bapsflib/lapd/_hdf/__init__.py
@@ -12,6 +12,6 @@
 The :mod:`bapsflib.lapd._hdf` package contains an assortment of tools
 to access and read out data written to HDF5 files by the LaPD.
 """
-from . import (file, lapdmap, lapdoverview)
-
 __all__ = ['file', 'lapdmap', 'lapdoverview']
+
+from . import (file, lapdmap, lapdoverview)

--- a/bapsflib/lapd/_hdf/tests/__init__.py
+++ b/bapsflib/lapd/_hdf/tests/__init__.py
@@ -12,12 +12,9 @@ __all__ = ['BaseFile', 'TestBase', 'with_bf', 'with_lapdf']
 
 import unittest as ut
 
+from bapsflib.utils.decorators import (with_bf, with_lapdf)
 from bapsflib._hdf import File as BaseFile
 from bapsflib._hdf.maps import FauxHDFBuilder
-from bapsflib._hdf.utils.tests import with_bf
-from functools import wraps
-
-from ..file import File
 
 
 def method_overridden(cls, obj, method: str) -> bool:
@@ -25,19 +22,6 @@ def method_overridden(cls, obj, method: str) -> bool:
     obj_method = method in obj.__class__.__dict__.keys()
     base_method = method in cls.__dict__.keys()
     return obj_method and base_method
-
-
-def with_lapdf(func):
-    """
-    Context decorator for managing the opening and closing LaPD HDF5
-    Files :class:`bapsflib.lapd._hdf.file.File`.  Intended for use on
-    test methods.
-    """
-    @wraps(func)
-    def wrapper(self, *args, **kwargs):
-        with File(self.f.filename) as lapdf:
-            return func(self, lapdf, *args, *kwargs)
-    return wrapper
 
 
 class TestBase(ut.TestCase):

--- a/bapsflib/lapd/_hdf/tests/__init__.py
+++ b/bapsflib/lapd/_hdf/tests/__init__.py
@@ -65,3 +65,19 @@ class TestBase(ut.TestCase):
         :param str method: method that should have NOT been over-written
         """
         self.assertTrue(method_overridden(base_class, obj, method))
+
+    @property
+    def filename(self) -> str:
+        return self.f.filename
+
+    @property
+    def control_path(self) -> str:
+        return 'Raw data + config'
+
+    @property
+    def digitizer_path(self) -> str:
+        return 'Raw data + config'
+
+    @property
+    def msi_path(self) -> str:
+        return 'MSI'

--- a/bapsflib/lapd/_hdf/tests/__init__.py
+++ b/bapsflib/lapd/_hdf/tests/__init__.py
@@ -8,6 +8,8 @@
 # License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
 #   license terms and contributor agreement.
 #
+__all__ = ['BaseFile', 'TestBase', 'with_bf', 'with_lapdf']
+
 import unittest as ut
 
 from bapsflib._hdf import File as BaseFile
@@ -16,8 +18,6 @@ from bapsflib._hdf.utils.tests import with_bf
 from functools import wraps
 
 from ..file import File
-
-__all__ = ['BaseFile', 'TestBase', 'with_bf', 'with_lapdf']
 
 
 def method_overridden(cls, obj, method: str) -> bool:

--- a/bapsflib/lapd/_hdf/tests/test_file.py
+++ b/bapsflib/lapd/_hdf/tests/test_file.py
@@ -37,7 +37,7 @@ class TestLaPDFile(TestBase):
 
     @with_bf
     @with_lapdf
-    def test_file(self, _lapdf: File, _bf: BaseFile):
+    def test_file(self, _bf: BaseFile, _lapdf: File):
         # must subclass `bapsflib._hdf.utils.file.File`
         self.assertIsInstance(_lapdf, bapsflib._hdf.utils.file.File)
 

--- a/bapsflib/lapd/constants/__init__.py
+++ b/bapsflib/lapd/constants/__init__.py
@@ -11,7 +11,7 @@
 """
 A package of relevant LaPD parameters and constants.
 """
+__all__ = ['constants', 'port_spacing', 'ref_port']
+
 from . import constants
 from .constants import (port_spacing, ref_port)
-
-__all__ = ['constants', 'port_spacing', 'ref_port']

--- a/bapsflib/lapd/tools/__init__.py
+++ b/bapsflib/lapd/tools/__init__.py
@@ -12,7 +12,7 @@
 This package contains a variety of tools (functions, classes, etc.)
 relevant to the LaPD and its configuration.
 """
+__all__ = ['tools', 'portnum_to_z', 'z_to_portnum']
+
 from . import tools
 from .tools import (portnum_to_z, z_to_portnum)
-
-__all__ = ['tools', 'portnum_to_z', 'z_to_portnum']

--- a/bapsflib/lapd/tools/tools.py
+++ b/bapsflib/lapd/tools/tools.py
@@ -8,14 +8,14 @@
 # License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
 #   license terms and contributor agreement.
 #
+__all__ = ['portnum_to_z', 'z_to_portnum']
+
 import astropy.units as u
 import numpy as np
 
 from typing import Union
 
 from .. import constants as const
-
-__all__ = ['portnum_to_z', 'z_to_portnum']
 
 
 def portnum_to_z(portnum: Union[int, float]) -> u.Quantity:

--- a/bapsflib/plasma/__init__.py
+++ b/bapsflib/plasma/__init__.py
@@ -8,6 +8,6 @@
 # License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
 #   license terms and contributor agreement.
 #
-from . import core
-
 __all__ = ['core']
+
+from . import core

--- a/bapsflib/plasma/core.py
+++ b/bapsflib/plasma/core.py
@@ -13,7 +13,7 @@
 # TODO: add collision frequencies
 # TODO: add mean-free-paths
 #
-"""Core plasma paramters in (cgs)."""
+"""Core plasma parameters in (cgs)."""
 
 import math
 

--- a/bapsflib/utils/__init__.py
+++ b/bapsflib/utils/__init__.py
@@ -8,6 +8,6 @@
 # License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
 #   license terms and contributor agreement.
 #
-from . import (errors, warnings)
-
 __all__ = ['errors', 'warnings']
+
+from . import (errors, warnings)

--- a/bapsflib/utils/__init__.py
+++ b/bapsflib/utils/__init__.py
@@ -8,6 +8,9 @@
 # License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
 #   license terms and contributor agreement.
 #
-__all__ = ['errors', 'warnings']
+"""
+Package of developer utilities.
+"""
+__all__ = ['decorators', 'errors', 'warnings']
 
-from . import (errors, warnings)
+from . import (decorators, errors, warnings)

--- a/bapsflib/utils/decorators.py
+++ b/bapsflib/utils/decorators.py
@@ -119,7 +119,7 @@ def with_bf(wfunc=None, *,
 
     def decorator(func):
         # import File here to avoid cyclical imports
-        from bapsflib._hdf import File
+        from bapsflib._hdf.utils.file import File
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
@@ -267,7 +267,7 @@ def with_lapdf(wfunc=None, *, filename: Union[str, None] = None):
 
     def decorator(func):
         # import File here to avoid cyclical imports
-        from bapsflib.lapd import File
+        from bapsflib.lapd._hdf.file import File
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/bapsflib/utils/decorators.py
+++ b/bapsflib/utils/decorators.py
@@ -135,9 +135,11 @@ def with_bf(wfunc=None, *,
             self = None  # type: Union[None, object]
             if 'self' in func_sig.parameters:
                 try:
-                    if hasattr(args[0], func.__name__):
+                    if hasattr(args[0], func.__name__):  # pragma: no branch
+                        # arg[0] is an object with method of the same name
+                        # as the decorated function
                         self = args[0]
-                except IndexError:
+                except IndexError:  # pragma: no cover
                     pass
 
             # update settings
@@ -160,7 +162,7 @@ def with_bf(wfunc=None, *,
                         if self.__getattribute__(name) is None:
                             continue
                         fsettings[name] = self.__getattribute__(name)
-                    except KeyError:
+                    except KeyError:  # pragma: no cover
                         pass
             for name in list(fsettings.keys()):
                 if fsettings[name] is None:

--- a/bapsflib/utils/decorators.py
+++ b/bapsflib/utils/decorators.py
@@ -105,7 +105,6 @@ def with_bf(wfunc=None, *,
             >>> # function keywords will still take precedence
             >>> foo(filename='test_2.hdf5')
             'test_2.hdf5'
-
     """
     # How to pass in file settings (listed in priority):
     # 1. function keywords
@@ -146,14 +145,20 @@ def with_bf(wfunc=None, *,
             for name in fsettings.keys():
                 if name in bound_args.arguments:
                     # look for setting in passed arguments
+                    if bound_args.arguments[name] is None:
+                        continue
                     fsettings[name] = bound_args.arguments[name]
                 elif name in bound_args.kwargs:
                     # look for setting in passed kwargs (if not in arguments)
+                    if bound_args.kwargs[name] is None:
+                        continue
                     fsettings[name] = bound_args.kwargs[name]
                 elif self is not None:
                     # if wrapped function is a method, and setting not passed
                     # as function argument then look to self
                     try:
+                        if self.__getattribute__(name) is None:
+                            continue
                         fsettings[name] = self.__getattribute__(name)
                     except KeyError:
                         pass
@@ -180,16 +185,148 @@ def with_bf(wfunc=None, *,
         return decorator
 
 
-def with_lapdf(func):
+def with_lapdf(wfunc=None, *, filename: Union[str, None] = None):
     """
     Context decorator for managing the opening and closing LaPD HDF5
-    Files :class:`bapsflib.lapd._hdf.file.File`.  Intended for use on
-    test methods.
-    """
-    from bapsflib.lapd import File
+    Files (:class:`bapsflib.lapd._hdf.file.File`).  An instance of the
+    LaPD HDF5 file is injected into the decorated function at the end of
+    the positional arguments.  The decorator is primarily designed for use
+    on test methods, but can also be used as a function decorator.
 
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        with File(self.f.filename) as lapdf:
-            return func(self, lapdf, *args, *kwargs)
-    return wrapper
+    :param wfunc: function or method to be wrapped
+    :param filename: name of the BaPSF HDF5 file
+
+    :example:
+        The HDF5 :data:`filename` can be passed to the decorator in three
+        ways (listed by predominance):
+
+        #. The wrapped function arguments.
+        #. If the wrapped function is a method, then through the
+           appropriately named :data:`self` attributes.
+        #. The decorator keywords.
+
+        **Defined with wrapped function arguments**::
+
+            >>> # as function keywords
+            >>> @with_lapdf
+            ... def foo(lapdf, **kwargs):
+            ...     # * bf will be the HDF5 file object
+            ...     # * do whatever is needed with bf and @with_bf will close
+            ...     #   the file at the end
+            ...     return lapdf.filename
+            >>> foo(filename='test.hdf5')
+            'test.hdf5'
+            >>>
+            >>> # as a function argument
+            >>> @with_lapdf
+            ... def foo(filename, lapdf, **kwargs):
+            ...     # use bf
+            ...     return lapdf.filename
+            ... foo('test.hdf5')
+            'test.hdf5'
+
+        **Defined with wrapped method attributes**::
+
+            >>> # use `self` to pass file settings
+            >>> class BehaveOnFile:
+            ...     def __init__(self):
+            ...         super().__init__()
+            ...         self.filename = 'test.hdf5'
+            ...
+            ...     @with_bf
+            ...     def foo(self, lapdf, **kwargs):
+            ...         return lapdf.filename
+            >>> a = BehaveOnFile()
+            >>> a.foo()
+            'test.hdf5'
+            >>>
+            >>> # but keywords will still take precedence
+            >>> a.foo(filename='test_2.hdf5')
+            'test_2.hdf5'
+
+        **Defined with decorator keywords**:
+
+            >>> # as function keywords
+            >>> @with_bf(filename='test.hdf5')
+            ... def foo(lapdf, **kwargs):
+            ...     return lapdf.filename
+            >>> foo()
+            'test.hdf5'
+            >>>
+            >>> # function keywords will still take precedence
+            >>> foo(filename='test_2.hdf5')
+            'test_2.hdf5'
+    """
+    # How to pass in file settings (listed in priority):
+    # 1. function keywords
+    # 2. self attributes
+    # 3. decorator keywords
+    #
+    # define decorator set file settings
+    settings = {'filename': filename}
+
+    def decorator(func):
+        # import File here to avoid cyclical imports
+        from bapsflib.lapd import File
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            # is decorated function a method
+            # - this relies on the convention that a method's first argument
+            #   is self
+            # - inspect.ismethod only works on bound methods, so it does
+            #   not work at time of decorating in class
+            #
+            func_sig = inspect.signature(func)
+            bound_args = func_sig.bind_partial(*args, **kwargs)
+            self = None  # type: Union[None, object]
+            if 'self' in func_sig.parameters:
+                try:
+                    if hasattr(args[0], func.__name__):
+                        self = args[0]
+                except IndexError:
+                    pass
+
+            # update settings
+            fsettings = settings.copy()
+            for name in fsettings.keys():
+                if name in bound_args.arguments:
+                    # look for setting in passed arguments
+                    if bound_args.arguments[name] is None:
+                        continue
+                    fsettings[name] = bound_args.arguments[name]
+                elif name in bound_args.kwargs:
+                    # look for setting in passed kwargs (if not in arguments)
+                    if bound_args.kwargs[name] is None:
+                        continue
+                    fsettings[name] = bound_args.kwargs[name]
+                elif self is not None:
+                    # if wrapped function is a method, and setting not passed
+                    # as function argument then look to self
+                    try:
+                        if self.__getattribute__(name) is None:
+                            continue
+                        fsettings[name] = self.__getattribute__(name)
+                    except KeyError:
+                        pass
+            for name in list(fsettings.keys()):
+                if fsettings[name] is None:
+                    if name == 'filename':
+                        raise ValueError("No valid file name specified.")
+                    else:
+                        del fsettings[name]
+            fname = fsettings.pop('filename')
+
+            # run function with in if statement
+            with File(fname) as lapdf:
+                args += (lapdf,)
+                return func(*args, *kwargs)
+
+        return wrapper
+
+    if wfunc is not None:
+        # This is a decorator call without arguments, e.g. @with_lapdf
+        return decorator(wfunc)
+    else:
+        # This is a factory call, e.g. @with_lapdf()
+        return decorator

--- a/bapsflib/utils/decorators.py
+++ b/bapsflib/utils/decorators.py
@@ -13,8 +13,6 @@ Decorators for the :mod:`bapsflib` package.
 """
 __all__ = ['with_bf', 'with_lapdf']
 
-from bapsflib._hdf import File as BaseFile
-from bapsflib.lapd import File as LaPDFile
 from functools import wraps
 
 
@@ -24,12 +22,15 @@ def with_bf(func):
     Files :class:`bapsflib._hdf.utils.file.File`.  Intended for use on
     test methods.
     """
+    # TODO: let with_bf args define control_path, digitzer_path, msi_path
+    from bapsflib._hdf import File
+
     @wraps(func)
     def wrapper(self, *args, **kwargs):
-        with BaseFile(self.f.filename,
-                      control_path='Raw data + config',
-                      digitizer_path='Raw data + config',
-                      msi_path='MSI') as bf:
+        with File(self.f.filename,
+                  control_path='Raw data + config',
+                  digitizer_path='Raw data + config',
+                  msi_path='MSI') as bf:
             return func(self, bf, *args, **kwargs)
     return wrapper
 
@@ -40,8 +41,10 @@ def with_lapdf(func):
     Files :class:`bapsflib.lapd._hdf.file.File`.  Intended for use on
     test methods.
     """
+    from bapsflib.lapd import File
+
     @wraps(func)
     def wrapper(self, *args, **kwargs):
-        with LaPDFile(self.f.filename) as lapdf:
+        with File(self.f.filename) as lapdf:
             return func(self, lapdf, *args, *kwargs)
     return wrapper

--- a/bapsflib/utils/decorators.py
+++ b/bapsflib/utils/decorators.py
@@ -1,0 +1,47 @@
+# This file is part of the bapsflib package, a Python toolkit for the
+# BaPSF group at UCLA.
+#
+# http://plasma.physics.ucla.edu/
+#
+# Copyright 2017-2019 Erik T. Everson and contributors
+#
+# License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
+#   license terms and contributor agreement.
+#
+"""
+Decorators for the :mod:`bapsflib` package.
+"""
+__all__ = ['with_bf', 'with_lapdf']
+
+from bapsflib._hdf import File as BaseFile
+from bapsflib.lapd import File as LaPDFile
+from functools import wraps
+
+
+def with_bf(func):
+    """
+    Context decorator for managing the opening and closing BaPSF HDF5
+    Files :class:`bapsflib._hdf.utils.file.File`.  Intended for use on
+    test methods.
+    """
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        with BaseFile(self.f.filename,
+                      control_path='Raw data + config',
+                      digitizer_path='Raw data + config',
+                      msi_path='MSI') as bf:
+            return func(self, bf, *args, **kwargs)
+    return wrapper
+
+
+def with_lapdf(func):
+    """
+    Context decorator for managing the opening and closing LaPD HDF5
+    Files :class:`bapsflib.lapd._hdf.file.File`.  Intended for use on
+    test methods.
+    """
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        with LaPDFile(self.f.filename) as lapdf:
+            return func(self, lapdf, *args, *kwargs)
+    return wrapper

--- a/bapsflib/utils/decorators.py
+++ b/bapsflib/utils/decorators.py
@@ -322,7 +322,7 @@ def with_lapdf(wfunc=None, *, filename: Union[str, None] = None):
             # run function with in if statement
             with File(fname) as lapdf:
                 args += (lapdf,)
-                return func(*args, *kwargs)
+                return func(*args, **kwargs)
 
         return wrapper
 

--- a/bapsflib/utils/decorators.py
+++ b/bapsflib/utils/decorators.py
@@ -26,7 +26,7 @@ def with_bf(wfunc=None, *,
             msi_path: Union[str, None] = None):
     """
     Context decorator for managing the opening and closing BaPSF HDF5
-    Files (:class:`bapsflib._hdf.utils.file.File`0.  An instance of the
+    Files (:class:`bapsflib._hdf.utils.file.File`).  An instance of the
     BaPSF HDF5 file is injected into the decorated function at the end of
     the positional arguments.  The decorator is primarily designed for use
     on test methods, but can also be used as a function decorator.

--- a/bapsflib/utils/decorators.py
+++ b/bapsflib/utils/decorators.py
@@ -284,9 +284,9 @@ def with_lapdf(wfunc=None, *, filename: Union[str, None] = None):
             self = None  # type: Union[None, object]
             if 'self' in func_sig.parameters:
                 try:
-                    if hasattr(args[0], func.__name__):
+                    if hasattr(args[0], func.__name__):  # pragma: no branch
                         self = args[0]
-                except IndexError:
+                except IndexError:  # pragma: no cover
                     pass
 
             # update settings
@@ -299,23 +299,28 @@ def with_lapdf(wfunc=None, *, filename: Union[str, None] = None):
                     fsettings[name] = bound_args.arguments[name]
                 elif name in bound_args.kwargs:
                     # look for setting in passed kwargs (if not in arguments)
-                    if bound_args.kwargs[name] is None:
+                    if bound_args.kwargs[name] is None:  # pragma: no cover
+                        # currently with_lapdf only takes filename as an
+                        # argument, this need to be tested if that changes
                         continue
                     fsettings[name] = bound_args.kwargs[name]
                 elif self is not None:
                     # if wrapped function is a method, and setting not passed
                     # as function argument then look to self
                     try:
-                        if self.__getattribute__(name) is None:
+                        if self.__getattribute__(
+                                name) is None:  # pragma: no cover
+                            # currently with_lapdf only takes filename as an
+                            # argument, this need to be tested if that changes
                             continue
                         fsettings[name] = self.__getattribute__(name)
-                    except KeyError:
+                    except KeyError:  # pragma: no cover
                         pass
             for name in list(fsettings.keys()):
                 if fsettings[name] is None:
                     if name == 'filename':
                         raise ValueError("No valid file name specified.")
-                    else:
+                    else:  # pragma: no cover
                         del fsettings[name]
             fname = fsettings.pop('filename')
 

--- a/bapsflib/utils/decorators.py
+++ b/bapsflib/utils/decorators.py
@@ -13,26 +13,171 @@ Decorators for the :mod:`bapsflib` package.
 """
 __all__ = ['with_bf', 'with_lapdf']
 
-from functools import wraps
+import functools
+import inspect
+
+from typing import Union
 
 
-def with_bf(func):
+def with_bf(wfunc=None, *,
+            filename: Union[str, None] = None,
+            control_path: Union[str, None] = None,
+            digitizer_path: Union[str, None] = None,
+            msi_path: Union[str, None] = None):
     """
     Context decorator for managing the opening and closing BaPSF HDF5
-    Files :class:`bapsflib._hdf.utils.file.File`.  Intended for use on
-    test methods.
-    """
-    # TODO: let with_bf args define control_path, digitzer_path, msi_path
-    from bapsflib._hdf import File
+    Files (:class:`bapsflib._hdf.utils.file.File`0.  An instance of the
+    BaPSF HDF5 file is injected into the decorated function at the end of
+    the positional arguments.  The decorator is primarily designed for use
+    on test methods, but can also be used as a function decorator.
 
-    @wraps(func)
-    def wrapper(self, *args, **kwargs):
-        with File(self.f.filename,
-                  control_path='Raw data + config',
-                  digitizer_path='Raw data + config',
-                  msi_path='MSI') as bf:
-            return func(self, bf, *args, **kwargs)
-    return wrapper
+    :param wfunc: function or method to be wrapped
+    :param filename: name of the BaPSF HDF5 file
+    :param control_path: internal HDF5 path for control devices
+    :param digitizer_path: internal HDF5 path for digitizers
+    :param msi_path: internal HDF5 path for MSI devices
+
+    :example:
+        The HDF5 file parameters (:data:`filename`, :data:`control_path`,
+        :data:`digitizer_path`, and :data:`msi_path`) can be passed to the
+        decorator in three ways (listed by predominance):
+
+        #. The wrapped function arguments.
+        #. If the wrapped function is a method, then through appropriately
+           named :data:`self` attributes.
+        #. The decorator keywords.
+
+        **Defined with wrapped function arguments**::
+
+            >>> # as function keywords
+            >>> @with_bf
+            ... def foo(bf, **kwargs):
+            ...     # * bf will be the HDF5 file object
+            ...     # * do whatever is needed with bf and @with_bf will close
+            ...     #   the file at the end
+            ...     return bf.filename
+            >>> foo(filename='test.hdf5', control_path='Raw data + config',
+            ...     digitizer_path='Raw data + config', msi_path='MSI')
+            'test.hdf5'
+            >>>
+            >>> # as a function argument
+            >>> @with_bf
+            ... def foo(filename, bf, **kwargs):
+            ...     # use bf
+            ...     return bf.filename
+            ... foo('test.hdf5')
+            'test.hdf5'
+
+        **Defined with wrapped method attributes**::
+
+            >>> # use `self` to pass file settings
+            >>> class BehaveOnFile:
+            ...     def __init__(self):
+            ...         super().__init__()
+            ...         self.filename = 'test.hdf5'
+            ...         self.control_path = 'Raw data + config'
+            ...         self.digitizer_path = 'Raw data + config'
+            ...         self.msi_path = 'MSI'
+            ...
+            ...     @with_bf
+            ...     def foo(self, bf, **kwargs):
+            ...         return bf.filename
+            >>> a = BehaveOnFile()
+            >>> a.foo()
+            'test.hdf5'
+            >>>
+            >>> # but keywords will still take precedence
+            >>> a.foo(filename='test_2.hdf5')
+            'test_2.hdf5'
+
+        **Defined with decorator keywords**:
+
+            >>> # as function keywords
+            >>> @with_bf(filename='test.hdf5',
+            ...          control_path='Raw data + config',
+            ...          digitizer_path='Raw data +config',
+            ...          msi_path='MSI')
+            ... def foo(bf, **kwargs):
+            ...     return bf.filename
+            >>> foo()
+            'test.hdf5'
+            >>>
+            >>> # function keywords will still take precedence
+            >>> foo(filename='test_2.hdf5')
+            'test_2.hdf5'
+
+    """
+    # How to pass in file settings (listed in priority):
+    # 1. function keywords
+    # 2. self attributes
+    # 3. decorator keywords
+    #
+    # define decorator set file settings
+    settings = {'filename': filename,
+                'control_path': control_path,
+                'digitizer_path': digitizer_path,
+                'msi_path': msi_path}
+
+    def decorator(func):
+        # import File here to avoid cyclical imports
+        from bapsflib._hdf import File
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+
+            # is decorated function a method
+            # - this relies on the convention that a method's first argument
+            #   is self
+            # - inspect.ismethod only works on bound methods, so it does
+            #   not work at time of decorating in class
+            #
+            func_sig = inspect.signature(func)
+            bound_args = func_sig.bind_partial(*args, **kwargs)
+            self = None  # type: Union[None, object]
+            if 'self' in func_sig.parameters:
+                try:
+                    if hasattr(args[0], func.__name__):
+                        self = args[0]
+                except IndexError:
+                    pass
+
+            # update settings
+            fsettings = settings.copy()
+            for name in fsettings.keys():
+                if name in bound_args.arguments:
+                    # look for setting in passed arguments
+                    fsettings[name] = bound_args.arguments[name]
+                elif name in bound_args.kwargs:
+                    # look for setting in passed kwargs (if not in arguments)
+                    fsettings[name] = bound_args.kwargs[name]
+                elif self is not None:
+                    # if wrapped function is a method, and setting not passed
+                    # as function argument then look to self
+                    try:
+                        fsettings[name] = self.__getattribute__(name)
+                    except KeyError:
+                        pass
+            for name in list(fsettings.keys()):
+                if fsettings[name] is None:
+                    if name == 'filename':
+                        raise ValueError("No valid file name specified.")
+                    else:
+                        del fsettings[name]
+            fname = fsettings.pop('filename')
+
+            # run function with in if statement
+            with File(fname, **fsettings) as bf:
+                args += (bf,)
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    if wfunc is not None:
+        # This is a decorator call without arguments, e.g. @with_bf
+        return decorator(wfunc)
+    else:
+        # This is a factory call, e.g. @with_bf()
+        return decorator
 
 
 def with_lapdf(func):
@@ -43,7 +188,7 @@ def with_lapdf(func):
     """
     from bapsflib.lapd import File
 
-    @wraps(func)
+    @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
         with File(self.f.filename) as lapdf:
             return func(self, lapdf, *args, *kwargs)

--- a/bapsflib/utils/tests/test_decorators.py
+++ b/bapsflib/utils/tests/test_decorators.py
@@ -310,6 +310,13 @@ class TestWithBF(ut.TestCase):
             self.assertEqual(bf_settings[1][name], settings[name])
         mock_bf_class.reset_mock()
 
+        # keywords still override self
+        bf_settings = sthing.foo(control_path='a new path')
+        self.assertTrue(mock_bf_class.called)
+        self.assertTrue(bf_settings[0])
+        self.assertEqual(bf_settings[1]['control_path'], 'a new path')
+        mock_bf_class.reset_mock()
+
         # missing 'control_path'
         cp = settings.pop('control_path')
         sthing = Something(**settings)
@@ -320,6 +327,8 @@ class TestWithBF(ut.TestCase):
             bf_settings[1]['control_path'],
             inspect.signature(BaPSFFile).parameters['control_path'].default)
         mock_bf_class.reset_mock()
+
+
 
 
 if __name__ == '__main__':

--- a/bapsflib/utils/tests/test_decorators.py
+++ b/bapsflib/utils/tests/test_decorators.py
@@ -32,7 +32,6 @@ class TestWithBF(ut.TestCase):
         super().setUpClass()
         cls.f = FauxHDFBuilder()
 
-
     def setUp(self) -> None:
         super().setUp()
 
@@ -49,13 +48,6 @@ class TestWithBF(ut.TestCase):
     @property
     def filename(self) -> str:
         return self.f.filename
-
-    @staticmethod
-    def foo_func():
-        pass
-
-    def foo_method(self):
-        pass
 
     @mock.patch(BaPSFFile.__module__ + '.' + BaPSFFile.__qualname__,
                 side_effect=BaPSFFile, autospec=True)

--- a/bapsflib/utils/tests/test_decorators.py
+++ b/bapsflib/utils/tests/test_decorators.py
@@ -1,0 +1,159 @@
+# This file is part of the bapsflib package, a Python toolkit for the
+# BaPSF group at UCLA.
+#
+# http://plasma.physics.ucla.edu/
+#
+# Copyright 2017-2019 Erik T. Everson and contributors
+#
+# License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
+#   license terms and contributor agreement.
+#
+import inspect
+import unittest as ut
+
+from bapsflib._hdf import File as BaPSFFile
+from bapsflib._hdf.maps import FauxHDFBuilder
+from bapsflib.lapd import File as LaPDFile
+from unittest import mock
+
+from ..decorators import (with_bf, with_lapdf)
+
+
+class TestWithBF(ut.TestCase):
+    """
+    Test case for decorator :func:`~bapsflib.utils.decorators.with_bf`.
+    """
+
+    f = NotImplemented  # type: FauxHDFBuilder
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # create HDF5 file
+        super().setUpClass()
+        cls.f = FauxHDFBuilder()
+
+
+    def setUp(self) -> None:
+        super().setUp()
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        self.f.reset()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # cleanup and close HDF5 file
+        super().tearDownClass()
+        cls.f.cleanup()
+
+    @property
+    def filename(self) -> str:
+        return self.f.filename
+
+    @staticmethod
+    def foo_func():
+        pass
+
+    def foo_method(self):
+        pass
+
+    @mock.patch(BaPSFFile.__module__ + '.' + BaPSFFile.__qualname__,
+                side_effect=BaPSFFile, autospec=True)
+    def test_settings_by_decorator(self, mock_bf_class):
+        # define file settings to be bassed to decorator
+        settings = {'filename': self.filename,
+                    'control_path': 'Raw data + config',
+                    'digitizer_path': 'Raw data + config',
+                    'msi_path': 'MSI'}
+
+        # create a function to mock
+        def foo(bf: BaPSFFile, **kwargs):
+            self.assertIsInstance(bf, BaPSFFile)
+            bapsf_settings = {
+                'filename': bf.filename,
+                'control_path': bf.CONTROL_PATH,
+                'digitizer_path': bf.DIGITIZER_PATH,
+                'msi_path': bf.MSI_PATH,
+            }
+            return bapsf_settings
+        mock_foo = mock.Mock(side_effect=foo, name='mock_foo', autospec=True)
+        mock_foo.__signature__ = inspect.signature(foo)
+
+        # -- set file settings with decorator parameters --
+        func = with_bf(mock_foo, **settings)
+        bf_settings = func()
+        self.assertTrue(mock_bf_class.called)
+        self.assertTrue(mock_foo.called)
+        for name in settings:
+            self.assertEqual(settings[name], bf_settings[name])
+
+        mock_foo.reset_mock()
+        mock_bf_class.reset_mock()
+
+        # traditional decorator call, like
+        # @with_bf(**settings)
+        #     def foo(bf):
+        #         pass
+        #
+        func = with_bf(**settings)(mock_foo)
+        bf_settings = func()
+        self.assertTrue(mock_bf_class.called)
+        self.assertTrue(mock_foo.called)
+        for name in settings:
+            self.assertEqual(settings[name], bf_settings[name])
+
+        mock_foo.reset_mock()
+        mock_bf_class.reset_mock()
+
+        # -- function keywords override decorator settings --
+        bf_settings = func(control_path='a different path')
+        self.assertTrue(mock_bf_class.called)
+        self.assertTrue(mock_foo.called)
+        self.assertEqual('a different path', bf_settings['control_path'])
+        for name in settings:
+            if name == 'control_path':
+                continue
+            self.assertEqual(settings[name], bf_settings[name])
+
+        mock_foo.reset_mock()
+        mock_bf_class.reset_mock()
+
+        # -- function arguments also override decorator settings --
+        del mock_foo
+
+        # create a function to mock
+        def foo(filename: str, bf: BaPSFFile):
+            self.assertIsInstance(bf, BaPSFFile)
+            bapsf_settings = {
+                'filename': bf.filename,
+                'control_path': bf.CONTROL_PATH,
+                'digitizer_path': bf.DIGITIZER_PATH,
+                'msi_path': bf.MSI_PATH,
+            }
+            return bapsf_settings
+
+        mock_foo = mock.Mock(side_effect=foo, name='mock_foo', autospec=True)
+        mock_foo.__signature__ = inspect.signature(foo)
+
+        filename = settings.pop('filename')
+        settings['filename'] = 'not a real file'
+        func = with_bf(**settings)(mock_foo)
+        bf_settings = func(filename)
+        self.assertTrue(mock_bf_class.called)
+        self.assertTrue(mock_foo.called)
+        self.assertEqual(bf_settings['filename'], filename)
+        for name in settings:
+            if name == 'filename':
+                continue
+            self.assertEqual(settings[name], bf_settings[name])
+
+        mock_foo.reset_mock()
+        mock_bf_class.reset_mock()
+
+
+
+
+
+
+if __name__ == '__main__':
+    ut.main()

--- a/bapsflib/utils/tests/test_decorators.py
+++ b/bapsflib/utils/tests/test_decorators.py
@@ -244,19 +244,31 @@ class TestWithBF(ut.TestCase):
         fname = settings.pop('filename')
         func = with_bf(mock_foo)
         bf_settings = func(fname, **settings)
+        self.assertTrue(mock_bf_class.called)
+        self.assertTrue(mock_foo.called)
         for name in bf_settings:
             if name == 'filename':
                 self.assertEqual(bf_settings[name], fname)
             else:
                 self.assertEqual(bf_settings[name], settings[name])
 
+        # reset mocks
+        mock_bf_class.reset_mock()
+        mock_foo.reset_mock()
+
         # settings defines 'control_path'=None
         settings['control_path'] = None
         bf_settings = func(fname, **settings)
+        self.assertTrue(mock_bf_class.called)
+        self.assertTrue(mock_foo.called)
         self.assertEqual(
             bf_settings['control_path'],
             inspect.signature(BaPSFFile).parameters['control_path'].default
         )
+
+        # reset mocks
+        mock_bf_class.reset_mock()
+        mock_foo.reset_mock()
 
         # settings defines 'filename'=None
         self.assertRaises(ValueError, func, None)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,46 @@
 Changelog
 =========
 
+1.0.1
+-----
+
+* Added Control Device mapping modules for:
+
+  * :doc:`NI_XZ <./src/bapsflib._hdf.maps.controls.nixz>` - a probe drive that
+    moves a probe in the XZ-plane
+    (`PR 22 <https://github.com/BaPSF/bapsflib/pull/22>`_)
+  * :doc:`NI_XYZ <./src/bapsflib._hdf.maps.controls.nixyz>` - a probe drive
+    that moves a probe withing an XYZ volume
+    (`PR 39 <https://github.com/BaPSF/bapsflib/pull/39>`_)
+
+* Update mapping module :mod:`~bapsflib._hdf.maps.digitizers.sis3301` to
+  handle variations seen in SmPD generated HDF5 files
+  (`PR 30 <https://github.com/BaPSF/bapsflib/pull/30>`_)
+
+* developed decorators :func:`~bapsflib.utils.decorators.with_bf` and
+  :func:`~bapsflib.utils.decorators.with_lapdf` to better context manage file
+  access to the HDF5 files
+  (`PR 23 <https://github.com/BaPSF/bapsflib/pull/23>`_)
+
+  * this allows tests for HDF5 files to run on Windows systems
+  * integrated CI `AppVeyor <https://www.appveyor.com/>`_
+
+* Allow function :func:`~bapsflib._hdf.utils.helpers.condition_shotnum` to
+  handle single element :mod:`numpy` arrays
+  (`PR 41 <https://github.com/BaPSF/bapsflib/pull/41>`_)
+
+* Refactor class
+  :class:`~bapsflib._hdf.utils.hdfreadcontrols.HDFReadControls` and module
+  :mod:`~bapsflib._hdf.utils.hdfreadcontrols` to be plural, which better
+  reflects the class behavior and is consistent with the bound method
+  :meth:`~bapsflib._hdf.utils.file.File.read_controls` on
+  :class:`~bapsflib._hdf.utils.file.File`.
+  (`PR 42 <https://github.com/BaPSF/bapsflib/pull/42>`_)
+
+* Setup continuation integration `pep8speaks <https://pep8speaks.com/>`_
+  (`PR 43 <https://github.com/BaPSF/bapsflib/pull/43>`_)
+
+
 1.0.0
 -----
 

--- a/docs/src/bapsflib.plasma.rst
+++ b/docs/src/bapsflib.plasma.rst
@@ -1,5 +1,5 @@
 bapsflib\.plasma
-=================
+================
 
 .. warning:: Package Currently Under Development
 

--- a/docs/src/bapsflib.rst
+++ b/docs/src/bapsflib.rst
@@ -13,5 +13,6 @@ bapsflib
 
     ./bapsflib._hdf
     ./bapsflib.lapd
+    ./bapsflib.utils
 
 .. ./bapsflib.plasma

--- a/docs/src/bapsflib.utils.decorators.rst
+++ b/docs/src/bapsflib.utils.decorators.rst
@@ -1,0 +1,15 @@
+bapsflib\.utils\.decorators
+===========================
+
+.. automodule:: bapsflib.utils.decorators
+    :show-inheritance:
+    :members:
+    :undoc-members:
+
+    .. rubric:: Functions
+
+    .. autosummary::
+        :nosignatures:
+
+        with_bf
+        with_lapdf

--- a/docs/src/bapsflib.utils.rst
+++ b/docs/src/bapsflib.utils.rst
@@ -1,0 +1,11 @@
+bapsflib\.utils
+===============
+
+.. automodule:: bapsflib.utils
+
+.. toctree::
+    :maxdepth: 2
+    :titlesonly:
+    :caption: Sub-Packages & Modules
+
+    bapsflib.utils.decorators


### PR DESCRIPTION
Merge in last remaining misc features to get to v1.0.1:

* update version string to `'1.0.1'`
* move `__all__` above imports (PEP8 - module level dunders follow docstrings)
* update `changelog.rst`
* move docorators `with_bf` and `with_lapdf` out of test packages and into module `bapsflib.utils.decorators`
  * decorators are generalized to work on functions and methods
  * file opening settings can be defined through (in priority) (1) function arguments, (2) appropriately named attributes on method's `self` argument, and (3) decorator keywords
  * tests created to cover `with_bf` and `with_lapdf`
  * source documentation page made for `bapsflib.utils.decorators`