### PR TITLE
Move metadata to setup.cfg and consolidate requirements

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -3,7 +3,7 @@ scanner:
     linter: pycodestyle  # check code with pycodestyle
 
 pycodestyle:
-    max-line-length: 79
+    max-line-length: 89
 
 only_mention_files_with_errors: True
 descending_issues_order: False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,6 @@ autoclass_content = "both"
 # 'sphinx.ext.imgmath'
 # 'sphinx.ext.mathjax'
 extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.githubpages',
               'sphinx.ext.mathjax',
               'sphinx.ext.autosummary']
 numfig = True  # enable figure and table numbering

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = [
+    "setuptools >= 41.2",
+    "wheel >= 0.29.0",
+]  # ought to mirror 'requirements/build.txt'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,8 @@
-# This file is part of the bapsflib package, a Python toolkit for the
-# BaPSF group at UCLA.
-#
-# http://plasma.physics.ucla.edu/
-#
-# Copyright 2017-2018 Erik T. Everson and contributors
-#
-# License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
-#   license terms and contributor agreement.
-#
-#
-# Required Packages w/ version
-astropy >= 2.0
-codecov >= 2.0.15
-coverage >= 4.5.1
-h5py >= 2.6
-numpy >= 1.12
-scipy >= 1.0.0
-#
-# Add Sphinx/Documentation requirements
--r docs/requirements.txt
+# all dependencies required to build, install, test, and doucment bapsflib
+# * look to the specific requirements/*.txt for specific needs
+# * this will mimic `pip install bapsflib[developer]` (excluding bapsflib)
+-r requirements/build.txt
+-r requirements/install.txt
+-r requirements/extras.txt
+-r requirements/tests.txt
+-r requirements/docs.txt

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,0 +1,4 @@
+# these are dependencies required to build the package distribution for installation
+# ought to mirror 'build-system.requires' under in pyproject.toml
+setuptools >= 41.2
+wheel >= 0.29.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,0 +1,5 @@
+# these are dependencies required to build package documentaiton
+# ought to mirror 'docs' under options.extras_require in config.cfg
+-r extras.txt
+sphinx <= 2.4.4
+sphinx_rtd_theme

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,0 +1,2 @@
+# these are "extra" dependencies to run advanced package features
+# ought to mirror 'extras' under options.extras_require in config.cfg

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -1,0 +1,7 @@
+# these are dependencies required to use the package
+# ought to mirror 'instal_requires' under 'options' in config.cfg
+astropy >= 3.1
+h5py >= 2.6
+numpy >= 1.14
+scipy >= 0.19
+setuptools >= 41.2

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,0 +1,5 @@
+# these are dependencies required to run package tests
+# ought to mirror 'tests' under options.extras_require in config.cfg
+-r extras.txt
+codecov >= 2.0.15
+coverage >= 4.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,71 @@
+[metadata]
+name = bapsflib
+author = Basic Plasma Science Facility
+maintainer = Erik T. Everson
+maintainer_email = eeverson@physics.ucla.edu
+description = A toolkit for handling data collected at BaPSF
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = 3-clause BSD
+license_file = LICENSES/LICENSE.txt
+url = https://github.com/BaPSF/bapsflib
+download_url = https://pypi.org/project/bapsflib/
+project_urls =
+    BaPSF = http://plasma.physics.ucla.edu/
+    Documentation = https://bapsflib.readthedocs.io/en/latest/
+    GitHub = https://github.com/BaPSF/bapsflib
+keywords = bapsf, HDF5, lapd, physics, plasma, plasma physics, science
+classifiers =
+    Intended Audience :: Developers
+    Intended Audience :: Education
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: BSD License
+    Natural Language :: English
+    Operating System :: MacOS
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX :: Linux
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Education
+    Topic :: Scientific/Engineering
+    Topic :: Scientific/Engineering :: Physics
+    Topic :: Software Development
+    Topic :: Software Development :: Libraries :: Python Modules
+
+[options]
+python_requires = >=3.6
+zip_safe = false
+packages = find:
+include_package_data = True
+setup_requires =
+    # PEP-518 encourages the use of pyproject.toml for defining
+    # build dependencies...they should be defined under build-system.requires
+install_requites =
+    # ought to mirror requirements/install.txt
+    astropy >= 3.1
+    h5py >= 2.6
+    numpy >= 1.14
+    scipy >= 0.19
+    setuptools >= 41.2
+
+[options.extras_require]
+extras =
+    # ought to mirror requirements/extras.txt
+    # for developers
+tests =
+    # ought to mirror requirements/tests.txt
+    %(extras)s
+    codecov >= 2.0.15
+    coverage >= 4.5.1
+docs =
+    # ought to mirror requirements/docs.txt
+    %(extras)s
+    sphinx <= 2.4.4
+    sphinx_rtd_theme
+developer =
+    # install everything for developers
+    %(docs)s
+    %(extras)s
+    %(tests)s

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 #
 # http://plasma.physics.ucla.edu/
 #
-# Copyright 2017-2018 Erik T. Everson and contributors
+# Copyright 2017-2020 Erik T. Everson and BaPSF Contributors
 #
 # License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
 #   license terms and contributor agreement.

--- a/setup.py
+++ b/setup.py
@@ -14,35 +14,14 @@ import codecs
 import os
 import re
 
-from setuptools import setup, find_packages
+from setuptools import setup
+from setuptools.config import read_configuration
 
 # find here
 here = os.path.abspath(os.path.dirname(__file__))
 
-# define CLASSIFIERS
-CLASSIFIERS = [
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "Intended Audience :: Education",
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
-    "Natural Language :: English",
-    "Operating System :: MacOS",
-    "Operating System :: Microsoft :: Windows",
-    "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Topic :: Education",
-    "Topic :: Scientific/Engineering",
-    "Topic :: Scientific/Engineering :: Physics",
-    "Topic :: Software Development",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-]
 
-
-# ---- Define helpers for version-ing                               ----
+# ---- Define helpers for version-ing                                       ----
 # - following 'Single-sourcing the package version' from 'Python
 #   Packaging User Guide'
 #   https://packaging.python.org/guides/single-sourcing-package-version/
@@ -61,39 +40,7 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
-# ---- Define long description                                      ----
-with open('README.md', 'r') as fh:
-    LONG_DESCRIPTION = fh.read()
-
-# ---- Perform setup                                                ----
-setup(
-    name='bapsflib',
-    version=find_version("bapsflib", "__init__.py"),
-    description='A toolkit for handling data collected at BaPSF.',
-    long_description=LONG_DESCRIPTION,
-    long_description_content_type='text/markdown',
-    scripts=[],
-    setup_requires=['astropy>=2.0',
-                    'h5py>=2.6',
-                    'numpy>=1.7',
-                    'scipy>=1.0.0'],
-    install_requires=['astropy>=2.0',
-                      'h5py>=2.6',
-                      'numpy>=1.7',
-                      'scipy>=1.0.0'],
-    python_requires='>=3.5',
-    author='Erik T. Everson',
-    author_email='eteveson@gmail.com',
-    license='3-clause BSD',
-    url='https://github.com/BaPSF/bapsflib',
-    keywords=['bapsf', 'HDF5', 'lapd', 'physics', 'plasma', 'science'],
-    classifiers=CLASSIFIERS,
-    packages=find_packages(),
-    zip_safe=False,
-    include_package_data=True,
-    package_urls={
-        "BaPSF": "http://plasma.physics.ucla.edu/",
-        "Documentation": "https://bapsflib.readthedocs.io/en/latest/",
-        "GitHub": "https://github.com/BaPSF/bapsflib",
-    }
-)
+# ---- Perform setup                                                        ----
+setup_params = read_configuration("setup.cfg")["options"]["extras_require"]
+setup_params["metadata"]["version"] = find_version("bapsflib", "__init__.py")
+setup(**setup_params)


### PR DESCRIPTION
1. Moves package metadata out of `setup.py` and into `setup.cfg`.
1. Creates `pyproject.toml`.
1. Consolidates requirements files and establish relations with the `extras_requires` defined in `setup.cfg`.
    - Create directory `./requirements/*.txt` where each `*.txt` mimics the requirements defined by `extras_requires` in `setup.cfg`.
    - Comments in both locations are added to establish "link-backs".
    - The `./requirements.txt` specifies all packages defined by the files in `./requirements/`.