### PR TITLE
Add YML configuration file for RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,6 @@ python:
   install:
     - method: pip
       path: .
-      extras_requirements:
+      extra_requirements:
         - docs
   system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,17 @@
+# Configuration file for Read the Docs
+#
+# https://docs.readthedocs.io/en/stable/config-file/index.html#
+
+version: 2
+
+formats:
+  - htmlzip
+
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extras_requirements:
+        - docs
+  system_packages: true


### PR DESCRIPTION
This adds the `.readthedocs.yml` configuration file for controlling Read the Docs builds.