### PR TITLE
Set package version using setuptools_scm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
 
 # install dependencies
 install:
-  - pip install -r requirements.txt
+  - pip install .[tests]
 
 # define test script to run
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,32 @@
 # languages
 language: python
 python:
-  - "3.5"
   - "3.6"
-# Enable 3.7 without globally enabling sudo and dist: xenial for other
-# build jobs
-# workaround https://github.com/travis-ci/travis-ci/issues/9815
-matrix:
-  include:
-    - python: "3.7"
-      dist: xenial
-      sudo: true
+  - "3.7"
+  - "3.8"
+
+os:
+  - linux
+  - osx
+  - windows
+
+# The number of commits cloned.  Setting to false will clone all commits.
+# Since __version__ is defined with setuptools_scm, the default depth of 50
+# could be insufficient.
+git:
+  depth: false
+
+jobs:
+  fast_finish: true
+
+## Enable 3.7 without globally enabling sudo and dist: xenial for other
+## build jobs
+## workaround https://github.com/travis-ci/travis-ci/issues/9815
+#matrix:
+#  include:
+#    - python: "3.7"
+#      dist: xenial
+#      sudo: true
 
 # install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ python:
 
 os:
   - linux
-  - osx
-  - windows
 
 # The number of commits cloned.  Setting to false will clone all commits.
 # Since __version__ is defined with setuptools_scm, the default depth of 50

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,15 +32,6 @@ git:
 jobs:
   fast_finish: true
 
-## Enable 3.7 without globally enabling sudo and dist: xenial for other
-## build jobs
-## workaround https://github.com/travis-ci/travis-ci/issues/9815
-#matrix:
-#  include:
-#    - python: "3.7"
-#      dist: xenial
-#      sudo: true
-
 # install dependencies
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
 
 # install dependencies
 install:
-  - pip install .[tests]
+  - pip install -r requirements/tests.txt
 
 # define test script to run
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
 
 # install dependencies
 install:
-  - pip install -r requirements/tests.txt
+  - pip install -r requirements.txt
 
 # define test script to run
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 #
 # http://plasma.physics.ucla.edu/
 #
-# Copyright 2017-2018 Erik T. Everson and contributors
+# Copyright 2017-2020 Erik T. Everson and contributors
 #
 # License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
 #   license terms and contributor agreement.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,24 @@
 # AppVeyor.com is a Continuous Integration service to build and run
 # tests under Windows
+image: Visual Studio 2017
+
 environment:
 
   matrix:
-    - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python38-x64"
+
+matrix:
+  fast_finish: true
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "ECHO %PATH%"
+  - "%PYTHON%\\python.exe -m pip install --upgrade pip"
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
 
 # Not a .NET project, package is built in the install step instead

--- a/bapsflib/__init__.py
+++ b/bapsflib/__init__.py
@@ -25,5 +25,48 @@ import pkg_resources
 
 from bapsflib import (_hdf, lapd, plasma, utils)
 
-# --- Define version ---------------------------------------------------
-__version__ = '1.0.1'
+# --- Define version -----------------------------------------------------------
+try:
+    # this places a runtime dependency on setuptools
+    #
+    # note: if there's any distribution metadata in your source files, then this
+    #       will find a version based on those files.  Keep distribution metadata
+    #       out of your repository unless you've intentionally installed the package
+    #       as editable (e.g. `pip install -e {bapsflib_directory_root}`),
+    #       but then __version__ will not be updated with each commit, it is
+    #       frozen to the version at time of install.
+    #
+    #: `bapsflib` version string
+    __version__ = pkg_resources.get_distribution("bapsflib").version
+except pkg_resources.DistributionNotFound:
+    # package is not installed
+    fallback_version = "unknown"
+    try:
+        # code most likely being used from source
+        # if setuptools_scm is installed then generate a version
+        from setuptools_scm import get_version
+
+        __version__ = get_version(
+            root="..", relative_to=__file__, fallback_version=fallback_version
+        )
+        del get_version
+        warn_add = "setuptools_scm failed to detect the version"
+    except ModuleNotFoundError:
+        # setuptools_scm is not installed
+        __version__ = fallback_version
+        warn_add = "setuptools_scm is not installed"
+
+    if __version__ == fallback_version:
+        from warnings import warn
+
+        warn(
+            f"bapsflib.__version__ not generated (set to 'unknown'), bapsflib is "
+            f"not an installed package and {warn_add}.",
+            RuntimeWarning,
+        )
+
+        del warn
+    del fallback_version, warn_add
+
+
+del pkg_resources

--- a/bapsflib/__init__.py
+++ b/bapsflib/__init__.py
@@ -19,11 +19,11 @@ http://plasma.physics.ucla.edu/
 bapsflib Repository:
 https://github.com/rocco8773/bapsflib
 """
-# --- Public API -------------------------------------------------------
+__all__ = ["lapd"]
 
-from . import _hdf
-from . import lapd
-from . import plasma
+import pkg_resources
+
+from bapsflib import (_hdf, lapd, plasma, utils)
 
 # --- Define version ---------------------------------------------------
 __version__ = '1.0.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
 requires = [
     "setuptools >= 41.2",
+    "setuptools_scm",
     "wheel >= 0.29.0",
 ]  # ought to mirror 'requirements/build.txt'
+build-backend = "setuptools.build_meta"

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,4 +1,5 @@
 # these are dependencies required to build the package distribution for installation
 # ought to mirror 'build-system.requires' under in pyproject.toml
 setuptools >= 41.2
+setuptools_scm
 wheel >= 0.29.0

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -5,3 +5,4 @@ h5py >= 2.6
 numpy >= 1.14
 scipy >= 0.19
 setuptools >= 41.2
+setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ install_requites =
     numpy >= 1.14
     scipy >= 0.19
     setuptools >= 41.2
+    setuptools_scm
 
 [options.extras_require]
 extras =

--- a/setup.py
+++ b/setup.py
@@ -19,25 +19,5 @@ from setuptools import setup
 # find here
 here = os.path.abspath(os.path.dirname(__file__))
 
-
-# ---- Define helpers for version-ing                                       ----
-# - following 'Single-sourcing the package version' from 'Python
-#   Packaging User Guide'
-#   https://packaging.python.org/guides/single-sourcing-package-version/
-#
-def read(*parts):
-    with codecs.open(os.path.join(here, *parts), 'r') as fp:
-        return fp.read()
-
-
-def find_version(*file_paths):
-    version_file = read(*file_paths)
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
-    if version_match:
-        return version_match.group(1)
-    raise RuntimeError("Unable to find version string.")
-
-
 # ---- Perform setup                                                        ----
-setup(version=find_version("bapsflib", "__init__.py"))
+setup(use_scm_version=True)

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,7 @@
 # License: Standard 3-clause BSD; see "LICENSES/LICENSE.txt" for full
 #   license terms and contributor agreement.
 #
-import codecs
 import os
-import re
 
 from setuptools import setup
 


### PR DESCRIPTION
Set package `__version__` using `setuptools_scm`, which leverages git scm (source-control management).

1. `__version__` is defined similarly to that in https://github.com/PlasmaPy/PlasmaPy/pull/774
1. In `setup.py` let `setup()` define version with `use_scm_version=True`.
1. Update `.travis.yml` to run tests on python 3.6-3.8 (on Linus).
1. Update `appveyor.yml` to run test on python 3.6-3.8 (for windows)