### PR TITLE
Setup gilesbot for Change Log checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,51 +1,68 @@
 [build-system]
 requires = [
-    "setuptools >= 41.2",
-    "setuptools_scm",
-    "wheel >= 0.29.0",
+  "setuptools >= 41.2",
+  "setuptools_scm",
+  "wheel >= 0.29.0",
 ]  # ought to mirror 'requirements/build.txt'
 build-backend = "setuptools.build_meta"
 
 [tool.towncrier]
-    package = "bapsflib"
-    filename = "CHANGELOG.rst"
-    directory = "changelog"
-    issue_format = "`#{issue} <https://github.com/BaPSF/bapsflib/pull/{issue}>`_"
-    title_format = "v{version} ({project_date})"
+  package = "bapsflib"
+  filename = "CHANGELOG.rst"
+  directory = "changelog"
+  issue_format = "`#{issue} <https://github.com/BaPSF/bapsflib/pull/{issue}>`_"
+  title_format = "v{version} ({project_date})"
 
-    [[tool.towncrier.type]]
-        directory = "breaking"
-        name = "Backwards Incompatible Changes"
-        showcontent = true
-
-    [[tool.towncrier.type]]
-      directory = "removal"
-      name = "Deprecations and Removals"
+  [[tool.towncrier.type]]
+      directory = "breaking"
+      name = "Backwards Incompatible Changes"
       showcontent = true
 
-    [[tool.towncrier.type]]
-      directory = "feature"
-      name = "Features"
-      showcontent = true
+  [[tool.towncrier.type]]
+    directory = "removal"
+    name = "Deprecations and Removals"
+    showcontent = true
 
-    [[tool.towncrier.type]]
-      directory = "bugfix"
-      name = "Bug Fixes"
-      showcontent = true
+  [[tool.towncrier.type]]
+    directory = "feature"
+    name = "Features"
+    showcontent = true
 
-    [[tool.towncrier.type]]
-      directory = "doc"
-      name = "Documentation Improvements"
-      showcontent = true
+  [[tool.towncrier.type]]
+    directory = "bugfix"
+    name = "Bug Fixes"
+    showcontent = true
 
-    [[tool.towncrier.type]]
-      directory = "trivial"
-      name = "Trivial/Internal Changes"
-      showcontent = true
+  [[tool.towncrier.type]]
+    directory = "doc"
+    name = "Documentation Improvements"
+    showcontent = true
+
+  [[tool.towncrier.type]]
+    directory = "trivial"
+    name = "Trivial/Internal Changes"
+    showcontent = true
 
 [tool.gilesbot]
-    [tool.gilesbot.pull_request]
-        enable = true
+  [tool.gilesbot.pull_request]
+    enable = true
 
-    [tool.gilesbot.towncrier_changelog]
-        encable = true
+  [tool.gilesbot.towncrier_changelog]
+    encable = true
+    changelog_skip_label = "No changelog entry needed"
+    help_url = "https://github.com/BaPSF/bapsflib/blob/master/changelog/README.rst"
+    changelog_missing = "Missing changelog entry"
+    changelog_missing_long = """
+    This pull request needs a changelog entry file in `changelog/NUMBER.TYPE.rst`.
+    For more information, consult
+    https://github.com/BaPSF/bapsflib/blob/master/changelog/README.rst . \
+    """
+    number_incorrect = "Incorrect changelog entry number (match PR!)"
+    number_incorrect_long = """
+    The changelog entry's number does not match this pull request's number. \
+    """
+    type_incorrect = "Incorrect changelog entry type (see list in changelog README)"
+    type_incorrect_long = """
+    The changelog entry for this PR must have one of the types
+    (as in NUMBER.TYPE.rst) as described in the changelog README). \
+    """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,10 @@ build-backend = "setuptools.build_meta"
       directory = "trivial"
       name = "Trivial/Internal Changes"
       showcontent = true
+
+[tool.gilesbot]
+    [tool.gilesbot.pull_request]
+        enable = true
+
+    [tool.gilesbot.towncrier_changelog]
+        encable = true


### PR DESCRIPTION
This PR setups up the [gilesbot](https://github.com/Cadair/giles) to check for proper `towncrier` change log entries.

According to https://github.com/PlasmaPy/PlasmaPy/pull/719#issuecomment-549155899, the actual check will not appear until it is in the master branch.