### PR TITLE
Improve indexing in anticipation of allowing h5py >= 3.0

### DIFF
--- a/bapsflib/_hdf/utils/helpers.py
+++ b/bapsflib/_hdf/utils/helpers.py
@@ -141,7 +141,8 @@ def build_sndr_for_simple_dset(
             if True in sni else np.empty(shape=0, dtype=np.uint32)
     else:
         # get 1st and last shot number
-        first_sn, last_sn = dset[[-1, 0], shotnumkey]
+        first_sn = dset[0, shotnumkey]
+        last_sn = dset[-1, shotnumkey]
 
         if last_sn - first_sn + 1 == dset.shape[0]:
             # shot numbers are sequential
@@ -284,7 +285,8 @@ def build_sndr_for_complex_dset(
                     "routines assumptions of a complex dataset")
     else:
         # get 1st and last shot number
-        first_sn, last_sn = dset[[-1, 0], shotnumkey]
+        first_sn = dset[0, shotnumkey]
+        last_sn = dset[-1, shotnumkey]
 
         # find sub-group index corresponding to the requested device
         # configuration

--- a/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
+++ b/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
@@ -855,8 +855,12 @@ class TestHDFReadData(TestBase):
         data = HDFReadData(_bf, brd, ch, config_name=config_name,
                            adc=adc, digitizer=digi, index=[10, -2])
         self.assertDataObj(data, _bf)
-        self.assertTrue(np.array_equal(data['shotnum'],
-                                       dheader[[-2, 10], shotnumkey]))
+        self.assertTrue(
+            np.array_equal(
+                data['shotnum'],
+                [dheader[10, shotnumkey], dheader[-2, shotnumkey]]
+            ),
+        )
 
         # invalid negative index
         with self.assertRaises(ValueError):

--- a/changelog/65.feature.rst
+++ b/changelog/65.feature.rst
@@ -1,0 +1,3 @@
+Make indexing of datasets more robust in a few locations in anticipation
+of allowing `h5py >= 3.0`, and thus accounting for `h5py`'s change in
+indexing behavior.


### PR DESCRIPTION
`h5py >= 3.0` has changed the order of it's indexing for datasets to be the reverse of what was in `h5py < 3.0`.  For example, ...

```python
# h5py < 3.0 indexed like
first, last =dataset[[-1, 0], "column name"]

# h5py >= 3.0 index like
first, last =dataset[[0, -1], "column name"]
```

To make `bapsflib`'s functionality more robust, the following approach is taken...

```python
first = dataset[0, "column name"]
last = dataset[-1, "column name"]
```