### PR TITLE
Add `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# This file allows reasonable git blame's without looking at
+# black formatting changes.
+# For details see
+# https://github.com/psf/black/blob/d3cc63316b10c3ddc0e6a97a71130f30598ba5ef/README.md#migrating-your-code-style-without-ruining-git-blame
+# https://www.moxio.com/blog/43/ignoring-bulk-change-commits-with-git-blame
+
+# Apply black to entire codebase
+2906fd682e0f9dd905fc5b7121c0fbf2caba7734
+
+# Apply isort to entire codebase
+e8e6bc1e62829aeaac859a9691890fb4c582dbdf

--- a/changelog/68.trivial.rst
+++ b/changelog/68.trivial.rst
@@ -1,2 +1,3 @@
 Add `.git-blame-ignore-revs` to package so `git blame` ignores the major
-refactoring commits from `isort` PR #66 and `black` PR #67.
+refactoring commits from `isort` PR :pr:`66` and `black` PR
+`#67 <https://github.com/BaPSF/bapsflib/pull/67>`_.

--- a/changelog/68.trivial.rst
+++ b/changelog/68.trivial.rst
@@ -1,3 +1,4 @@
 Add `.git-blame-ignore-revs` to package so `git blame` ignores the major
-refactoring commits from `isort` PR :pr:`66` and `black` PR
-`#67 <https://github.com/BaPSF/bapsflib/pull/67>`_.
+refactoring commits from
+`isort` PR `#66 <https://github.com/BaPSF/bapsflib/pull/66>`_
+and `black` PR`#67 <https://github.com/BaPSF/bapsflib/pull/67>`_.

--- a/changelog/68.trivial.rst
+++ b/changelog/68.trivial.rst
@@ -1,0 +1,2 @@
+Add `.git-blame-ignore-revs` to package so `git blame` ignores the major
+refactoring commits from `isort` PR #66 and `black` PR #67.


### PR DESCRIPTION
Add `.git-blame-ignore-revs` so `git blame` will ignore mass refactoring from `isort` (PR #66 e8e6bc1e62829aeaac859a9691890fb4c582dbdf) and `black` (PR #67 2906fd682e0f9dd905fc5b7121c0fbf2caba7734).

This will make `git blame` look past the two major refactoring commits to get the last relevant `git commit` comment.

More details can be read at...

https://github.com/psf/black/blob/d3cc63316b10c3ddc0e6a97a71130f30598ba5ef/README.md#migrating-your-code-style-without-ruining-git-blame
https://www.moxio.com/blog/43/ignoring-bulk-change-commits-with-git-blame
