### PR TITLE
Drop support for Python 3.6, Extend CI tests to Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,13 +21,13 @@ jobs:
       matrix:
         include:
           # mark default
-          - python: '3.8'
+          - python: '3.10'
             os: ubuntu-latest
             do-coverage: false
             name-modifier: ''
 
           # mark case for coverage reporting
-          - python: '3.6'
+          - python: '3.7'
             os: ubuntu-latest
             do-coverage: true
             name-modifier: 'with Coverage'
@@ -66,14 +66,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.6', '3.7', '3.8']
+        python: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest, macos-latest, windows-latest]
 
         exclude:
           # these were done in base-tests
-          - python: '3.8'
+          - python: '3.10'
             os: ubuntu-latest
-          - python: '3.6'
+          - python: '3.7'
             os: ubuntu-latest
 
     steps:
@@ -104,11 +104,11 @@ jobs:
         include:
           - spec-name: h5py v2.8
             min-install: h5py==2.8.0
-            python: 3.6
+            python: '3.7'
 
           - spec-name: h5py v2.8 numpy v1.14
             min-install: h5py==2.8.0 numpy==1.14
-            python: 3.6
+            python: '3.7'
 
     steps:
       - name: Checkout code

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,9 +25,10 @@ classifiers =
     Operating System :: Microsoft :: Windows
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Education
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Physics
@@ -35,7 +36,7 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 zip_safe = false
 packages = find:
 include_package_data = True


### PR DESCRIPTION
This PR officially drop support for Python 3.6 and extends the CI tests to Python 3.10.