### PR TITLE
Set requirement `black==22.3.0`

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Which black version
         uses: psf/black@stable
         with:
-          version: "${{ env.BLACK_VERSION }}"
+          version: "${{ env.BLACK_VERSION }} click==${{ CLICK_VERSION }}"
           options: "--version"
       - name: Run black checks
         uses: psf/black@stable

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Which black version
         uses: psf/black@stable
         with:
-          version: "${{ env.BLACK_VERSION }} click==${{ CLICK_VERSION }}"
+          version: "${{ env.BLACK_VERSION }} click==${{ env.CLICK_VERSION }}"
           options: "--version"
       - name: Run black checks
         uses: psf/black@stable

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -52,7 +52,7 @@ jobs:
           echo "BLACK_VERSION=${BLACKVERSION}" >> $GITHUB_ENV
           CLICKVERSION=$(python -c "import click; print(click.__version__)")
           echo "CLICK_VERSION=${CLICKVERSION}" >> $GITHUB_ENV
-          echo ${BLACKVERSION}
+          echo ${BLACKVERSION} click==${CLICKVERSION}
       - name: Which black version
         uses: psf/black@stable
         with:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -45,6 +45,7 @@ jobs:
           python-version: 3.8
       - name: Install black
         run: |
+          echo ${{ env.GITHUB_ACTION_PATH }}
           python -m pip install -r requirements/extras.txt
       - name: Retrieve black version
         run: |

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -45,19 +45,15 @@ jobs:
           python-version: 3.8
       - name: Install black
         run: |
-          echo ${{ GITHUB_ACTION_PATH }}
           python -m pip install -r requirements/extras.txt
       - name: Retrieve black version
         run: |
           BLACKVERSION=$(python -c "import black; print(black.__version__)")
           echo "BLACK_VERSION=${BLACKVERSION}" >> $GITHUB_ENV
-          CLICKVERSION=$(python -c "import click; print(click.__version__)")
-          echo "CLICK_VERSION=${CLICKVERSION}" >> $GITHUB_ENV
-          echo ${BLACKVERSION} click==${CLICKVERSION}
       - name: Which black version
         uses: psf/black@stable
         with:
-          version: "${{ env.BLACK_VERSION }} click==${{ env.CLICK_VERSION }}"
+          version: "${{ env.BLACK_VERSION }}"
           options: "--version"
       - name: Run black checks
         uses: psf/black@stable

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -50,6 +50,8 @@ jobs:
         run: |
           BLACKVERSION=$(python -c "import black; print(black.__version__)")
           echo "BLACK_VERSION=${BLACKVERSION}" >> $GITHUB_ENV
+          CLICKVERSION=$(python -c "import click; print(click.__version__)")
+          echo "CLICK_VERSION=${CLICKVERSION}" >> $GITHUB_ENV
       - name: Which black version
         uses: psf/black@stable
         with:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -52,6 +52,7 @@ jobs:
           echo "BLACK_VERSION=${BLACKVERSION}" >> $GITHUB_ENV
           CLICKVERSION=$(python -c "import click; print(click.__version__)")
           echo "CLICK_VERSION=${CLICKVERSION}" >> $GITHUB_ENV
+          echo ${BLACKVERSION}
       - name: Which black version
         uses: psf/black@stable
         with:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: 3.8
       - name: Install black
         run: |
-          echo ${{ env.GITHUB_ACTION_PATH }}
+          echo ${{ GITHUB_ACTION_PATH }}
           python -m pip install -r requirements/extras.txt
       - name: Retrieve black version
         run: |

--- a/bapsflib/_hdf/maps/digitizers/siscrate.py
+++ b/bapsflib/_hdf/maps/digitizers/siscrate.py
@@ -753,7 +753,7 @@ class HDFMapDigiSISCrate(HDFMapDigiTemplate):
                     if sample_ave == 0:
                         sample_ave = None
                     else:
-                        sample_ave = 2 ** sample_ave
+                        sample_ave = 2**sample_ave
 
             # determine clock rate
             if adc_name == "SIS 3305":

--- a/bapsflib/_hdf/maps/digitizers/tests/test_siscrate.py
+++ b/bapsflib/_hdf/maps/digitizers/tests/test_siscrate.py
@@ -1087,7 +1087,7 @@ class TestSISCrate(DigitizerTestCase):
         _map = self.map
         for conn in _map.configs[config_name][adc]:
             if conn[0] == brd:
-                self.assertEqual(conn[2]["sample average (hardware)"], 2 ** 5)
+                self.assertEqual(conn[2]["sample average (hardware)"], 2**5)
 
         self.dgroup[adc_config_path].attrs[sp2a_key] = sp2a
 

--- a/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
+++ b/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
@@ -786,7 +786,7 @@ class TestHDFReadData(TestBase):
         old_offset = data.info["voltage offset"]
         data.info["bit"] = 10
         data.info["voltage offset"] = -1.0 * u.volt
-        dv = 2.0 * abs(-1.0) / ((2.0 ** 10) - 1.0)
+        dv = 2.0 * abs(-1.0) / ((2.0**10) - 1.0)
         self.assertIsInstance(data.dv, u.Quantity)
         self.assertEqual(data.dv.value, dv)
         self.assertEqual(data.dv.unit, u.volt)

--- a/bapsflib/plasma/core.py
+++ b/bapsflib/plasma/core.py
@@ -282,7 +282,7 @@ def oLH(Bo, m_i, n_i, Z, **kwargs):
     _opi = opi(**_args)
     _oce = oce(**_args)
     _oci = oci(**_args)
-    first_term = 1.0 / ((_oci ** 2) + (_opi ** 2))
+    first_term = 1.0 / ((_oci**2) + (_opi**2))
     second_term = 1.0 / math.fabs(_oce * _oci)
     _olh = math.sqrt(1.0 / (first_term + second_term))
     return FloatUnit(_olh, "rad s^-1")
@@ -331,7 +331,7 @@ def oUH(Bo, n_e, **kwargs):
     """
     _ope = ope(n_e)
     _oce = oce(Bo)
-    _ouh = math.sqrt((_ope ** 2) + (_oce ** 2))
+    _ouh = math.sqrt((_ope**2) + (_oce**2))
     return FloatUnit(_ouh, "rad s^-1")
 
 

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,4 +1,5 @@
 # these are "extra" dependencies to run advanced package features
 # ought to mirror 'extras' under options.extras_require in config.cfg
 black==21.7b0
+click < 8.1
 isort

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,5 +1,4 @@
 # these are "extra" dependencies to run advanced package features
 # ought to mirror 'extras' under options.extras_require in config.cfg
-black==21.7b0
-click < 8.1
+black==22.3.0
 isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ extras =
     # ought to mirror requirements/extras.txt
     # for developers
     black==21.7b0
+    click < 8.1
     isort
 tests =
     # ought to mirror requirements/tests.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,8 +52,7 @@ install_requires =
 extras =
     # ought to mirror requirements/extras.txt
     # for developers
-    black==21.7b0
-    click < 8.1
+    black==22.3.0
     isort
 tests =
     # ought to mirror requirements/tests.txt


### PR DESCRIPTION
Set requirement `black==22.3.0`...

- Eliminates the linter CI failures due to the release of `click==8.1`
- Refactor code to `black==22.3.0` standards
