### PR TITLE
Set upper limit for numpy to `< 1.23`

### DIFF
--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -3,5 +3,5 @@
 -r build.txt
 astropy >= 3.1, <= 4.1
 h5py >= 2.8, <= 2.10.0
-numpy >= 1.15
+numpy >= 1.15, < 1.23
 scipy >= 0.19

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     # ought to mirror requirements/install.txt
     astropy >= 3.1, <= 4.1
     h5py >= 2.8, <= 2.10.0
-    numpy >= 1.15
+    numpy >= 1.15, < 1.23
     scipy >= 0.19
 
 [options.extras_require]


### PR DESCRIPTION
`numpy.asscalar` was deprecated in `numpy` `v1.16` and officially removed in `v1.23`.  However, `bapsflib` currently depends on older versions of `astropy` that use `numpy.asscalar`.