### PR TITLE
Add to `linters` GA workflow `codespell`

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -86,8 +86,8 @@ jobs:
         echo "matches a dictionary entry, it looks for a set of common misspellings"
         echo "in order to reduce the number of false positives."
         echo
-        echo "After codespell has been installed locally (`pip install codespell`),"
-        echo "running the command `codespell -i 2 -w` will interactively go through"
+        echo "After codespell has been installed locally ('pip install codespell'),"
+        echo "running the command 'codespell -i 2 -w' will interactively go through"
         echo "misspellings and suggest one or more replacements. Add any false"
         echo "positives under ignore-words-list under [codespell] in setup.cfg."
         echo

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -60,3 +60,36 @@ jobs:
         with:
           version: "${{ env.BLACK_VERSION }}"
           options: "--check --diff --color"
+
+  codespell:
+    name: codespell
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --progress-bar off -r requirements/extras.txt
+    - name: Codespell README
+      run: |
+        echo
+        echo "Codespell finds typos in source code. Rather than checking if each word"
+        echo "matches a dictionary entry, it looks for a set of common misspellings"
+        echo "in order to reduce the number of false positives."
+        echo
+        echo
+        echo "After codespell has been installed locally (`pip install codespell`),"
+        echo "running the command `codespell -i 2 -w` will interactively go through"
+        echo "misspellings and suggest one or more replacements. Add any false"
+        echo "positives under ignore-words-list under [codespell] in setup.cfg."
+    - name: Run test
+      run: |
+        codespell .

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -77,6 +77,7 @@ jobs:
         python-version: 3.8
     - name: Install Python dependencies
       run: |
+        python -m pip install --progress-bar off pip --upgrade
         python -m pip install --progress-bar off -r requirements/extras.txt
     - name: Codespell README
       run: |
@@ -85,11 +86,11 @@ jobs:
         echo "matches a dictionary entry, it looks for a set of common misspellings"
         echo "in order to reduce the number of false positives."
         echo
-        echo
         echo "After codespell has been installed locally (`pip install codespell`),"
         echo "running the command `codespell -i 2 -w` will interactively go through"
         echo "misspellings and suggest one or more replacements. Add any false"
         echo "positives under ignore-words-list under [codespell] in setup.cfg."
+        echo
     - name: Run test
       run: |
         codespell .

--- a/bapsflib/_hdf/maps/controls/parsers.py
+++ b/bapsflib/_hdf/maps/controls/parsers.py
@@ -57,7 +57,7 @@ class CLParse(object):
         Applies a the REs defined in `patterns` to parse the command
         list.
 
-        :param patterns: list or raw stings defining REs for parsing
+        :param patterns: list or raw strings defining REs for parsing
             the command list
         :type patterns: str or list of strings
         :return: (bool, dict)
@@ -271,7 +271,7 @@ class CLParse(object):
         Prints to the results of applying the REs in patterns to the
         command list.  Pretty print of :meth:`apply_patterns`.
 
-        :param patterns: list or raw stings defining REs for parsing
+        :param patterns: list or raw strings defining REs for parsing
             the command list
         :type patterns: str or list of strings
         """

--- a/bapsflib/_hdf/maps/digitizers/tests/fauxsiscrate.py
+++ b/bapsflib/_hdf/maps/digitizers/tests/fauxsiscrate.py
@@ -63,7 +63,7 @@ class FauxSISCrate(h5py.Group):
                 warn("`val` not valid, no update performed")
                 return
 
-            # check agains 'SIS 3305' mode
+            # check against 'SIS 3305' mode
             # - prevent enabling channels that can't be enabled for
             #   the SIS 3305 mode
             if self.sis3305_mode == 2:

--- a/bapsflib/_hdf/maps/digitizers/tests/test_siscrate.py
+++ b/bapsflib/_hdf/maps/digitizers/tests/test_siscrate.py
@@ -465,7 +465,7 @@ class TestSISCrate(DigitizerTestCase):
             )
         cgroup.attrs["SIS crate config indices"] = indices
 
-        # adc configuration group has a configuration indes that     (4)
+        # adc configuration group has a configuration index that     (4)
         # is NOT defined in the top-level configuration group
         # - same code-block is triggered by #3
         cgroup = self.dgroup[config_path]
@@ -1164,7 +1164,7 @@ class TestSISCrate(DigitizerTestCase):
         )
         self.assertIsNone(_map._parse_config_name(dset_name))
 
-        # config group is missing key attributs
+        # config group is missing key attributes
         attrs = (
             "SIS crate board types",
             "SIS crate config indices",

--- a/bapsflib/_hdf/maps/msi/tests/common.py
+++ b/bapsflib/_hdf/maps/msi/tests/common.py
@@ -154,7 +154,7 @@ class MSIDiagnosticTestCase(ut.TestCase):
         )
 
         # ['shotnum']['dset field']
-        # - is a tuple of stings
+        # - is a tuple of strings
         # - length 1 or length of 'dset paths'
         self.assertIsInstance(_map.configs["shotnum"]["dset field"], tuple)
         self.assertTrue(

--- a/bapsflib/_hdf/utils/hdfreadcontrols.py
+++ b/bapsflib/_hdf/utils/hdfreadcontrols.py
@@ -392,7 +392,7 @@ class HDFReadControls(np.ndarray):
                                 # necessary field but you want the read
                                 # out to still function
                                 # - e.g. 'xyz' but the dataset only
-                                #   contains values fo 'x' and 'z'
+                                #   contains values of 'x' and 'z'
                                 #   (the NI_XZ module)
                                 #
                                 # create zero array

--- a/bapsflib/_hdf/utils/tests/test_helpers.py
+++ b/bapsflib/_hdf/utils/tests/test_helpers.py
@@ -594,7 +594,7 @@ class TestConditionShotnum(TestBase):
             "c2": "Shot number",
         }
 
-        # invalid shotnum slices (creats NULL arrays)
+        # invalid shotnum slices (creates NULL arrays)
         with self.assertRaises(ValueError):
             _sn = condition_shotnum(slice(-1, -4, 1), dset_dict, shotnumkey_dict)
 
@@ -618,7 +618,7 @@ class TestConditionShotnum(TestBase):
 
     def test_shotnum_ndarray(self):
         # shotnum invalid
-        # 1. is not 1 dimentional
+        # 1. is not 1 dimensional
         # 2. has fields
         # 3. is not np.integer
         # 4. would result in NULL

--- a/bapsflib/lapd/_hdf/tests/test_lapdmap.py
+++ b/bapsflib/lapd/_hdf/tests/test_lapdmap.py
@@ -60,7 +60,7 @@ class TestLaPDMap(TestBase):
 
         # -- examine `is_lapd` and `lapd_version`                   ----
         #
-        # By defualt, FauxHDFBuilder adds the
+        # By default, FauxHDFBuilder adds the
         # 'LaPD HDF5 software version' attribute to the test file.
         lapd_version = _bytes_to_str(self.f.attrs["LaPD HDF5 software version"])
         self.assertTrue(_map.is_lapd)
@@ -142,7 +142,7 @@ class TestLaPDMap(TestBase):
             self.f[path].attrs[aname] = old_val
         del self.f[path].attrs["z"]
 
-        # -- `__init__` waring                                      ----
+        # -- `__init__` warning                                     ----
         with mock.patch.object(
             LaPDMap, "is_lapd", new_callable=mock.PropertyMock, return_value=False
         ) as mock_il:

--- a/bapsflib/lapd/constants/constants.py
+++ b/bapsflib/lapd/constants/constants.py
@@ -115,7 +115,7 @@ class SouthCathode(object):
                     1.0,
                     system="cgs",
                 )
-                self._cathode_descr = "barium-oxide coated nickle"
+                self._cathode_descr = "barium-oxide coated nickel"
                 self._lifespan = (NotImplemented, NotImplemented)
 
     @property

--- a/changelog/86.pkg_management.rst
+++ b/changelog/86.pkg_management.rst
@@ -1,0 +1,2 @@
+Added a `codespell <https://github.com/codespell-project/codespell>`_
+test to the :file:`linters.yml` GitHub Action workflow.

--- a/changelog/86.trivial.rst
+++ b/changelog/86.trivial.rst
@@ -1,0 +1,2 @@
+Added `codespell <https://github.com/codespell-project/codespell>`_
+as a package "extras" dependency.

--- a/docs/changelog/1.0.1.rst
+++ b/docs/changelog/1.0.1.rst
@@ -7,7 +7,7 @@ v1.0.1 (2019-06-01)
     moves a probe in the XZ-plane
     (`PR 22 <https://github.com/BaPSF/bapsflib/pull/22>`_)
   * :doc:`NI_XYZ <../api_static/bapsflib._hdf.maps.controls.nixyz>` - a probe drive
-    that moves a probe withing an XYZ volume
+    that moves a probe within an XYZ volume
     (`PR 39 <https://github.com/BaPSF/bapsflib/pull/39>`_)
 
 * Update mapping module :mod:`~bapsflib._hdf.maps.digitizers.sis3301` to

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,7 +62,7 @@ select :ibf:`Download ZIP`, save the zip file to the desired directory,
 and unpack.
 
 After getting a copy of the :mod:`bapsflib` package (via clone or
-downlaod), navigate to the main package directory, where the package
+download), navigate to the main package directory, where the package
 :file:`setup.py` file is located, and execute
 
 .. code-block:: bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# all dependencies required to build, install, test, and doucment bapsflib
+# all dependencies required to build, install, test, and document bapsflib
 # * look to the specific requirements/*.txt for specific needs
 # * this will mimic `pip install bapsflib[developer]` (excluding bapsflib)
 -r requirements/build.txt

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
-# these are dependencies required to build package documentaiton
+# these are dependencies required to build package documentation
 # ought to mirror 'docs' under options.extras_require in config.cfg
 -r install.txt
 -r extras.txt

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,4 +1,5 @@
 # these are "extra" dependencies to run advanced package features
 # ought to mirror 'extras' under options.extras_require in config.cfg
 black==22.3.0
+codespell
 isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ extras =
     # ought to mirror requirements/extras.txt
     # for developers
     black==22.3.0
+    codespell
     isort
 tests =
     # ought to mirror requirements/tests.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,3 +74,8 @@ developer =
     %(docs)s
     %(extras)s
     %(tests)s
+
+[codespell]
+skip = *.png,*cache*,*egg*,.git,.hypothesis,.idea,.tox,_build,venv
+ignore-words-list =
+    crate,


### PR DESCRIPTION
This PR does:

1. Adds `codespell` as an extras package dependency.
2. Defines `codespell`'s configuration in the `setup.cfg`.
3. Adds a `codespell` check to the `linters.yml` GA workflow.
4. Corrects miss spellings identified by `codespell`.