### PR TITLE
MNT: Change log bot has moved to Scientific Python

### DIFF
--- a/.github/workflows/check_pr_changelog.yml
+++ b/.github/workflows/check_pr_changelog.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - name: Look for changelog
         uses: rocco8773/actions-towncrier-changelog@vRoc
-        # TODO: return back to pllim when rocco8773 'vRoc' branch is pushed upstream
-        # uses: pllim/actions-towncrier-changelog@main
+        # TODO: return back to scientific-python when rocco8773 'vRoc' branch is pushed upstream
+        # uses: scientific-python/action-towncrier-changelog@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOT_USERNAME: changelog_bot


### PR DESCRIPTION
I moved the bot upstream to Scientific Python. It is unfortunate that you have to fork it and use it like this. We would welcome a PR to https://github.com/scientific-python/action-towncrier-changelog if you ever wishes to contribute upstream. Thanks!

xref https://github.com/scientific-python/action-towncrier-changelog/issues/4