### PR TITLE
Update `readthedocs.yml` to remove deprecated settings

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,11 +7,18 @@ version: 2
 formats:
   - htmlzip
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.10'
+  apt_packages:
+  - graphviz
+
+sphinx:
+  configuration: docs/conf.py
+
 python:
-  version: 3.7
   install:
-    - requirements: requirements/install.txt
     - requirements: requirements/docs.txt
-    - method: setuptools
+    - method: pip
       path: .
-  system_packages: true

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,7 +2,7 @@
 # ought to mirror 'docs' under options.extras_require in config.cfg
 -r install.txt
 -r extras.txt
-sphinx >= 3.2.0
+sphinx >= 3.2.0, < 7.0
 sphinx-automodapi >= 0.13
 sphinx-changelog
 sphinx-gallery

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ tests =
 docs =
     # ought to mirror requirements/docs.txt
     %(extras)s
-    sphinx >= 3.2.0
+    sphinx >= 3.2.0, < 7.0
     sphinx-automodapi >= 0.13
     sphinx-changelog
     sphinx-gallery


### PR DESCRIPTION
See the following RTD notice

https://blog.readthedocs.com/drop-support-system-packages/