### PR TITLE
Remove dependency restriction `numpy < 2.0`

### DIFF
--- a/bapsflib/_hdf/maps/controls/parsers.py
+++ b/bapsflib/_hdf/maps/controls/parsers.py
@@ -248,7 +248,7 @@ class CLParse(object):
                 else:
                     # 'command list' is a string
                     mlen = len(max(cls_dict[name]["command list"], key=lambda x: len(x)))
-                    cls_dict[name]["dtype"] = np.dtype((np.unicode_, mlen))
+                    cls_dict[name]["dtype"] = np.dtype((np.str_, mlen))
 
             # convert lists to tuples
             # - first check dict `name` has not been deleted

--- a/bapsflib/_hdf/maps/controls/tests/test_parsers.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_parsers.py
@@ -228,7 +228,7 @@ class TestCLParse(ut.TestCase):
                     self.assertEqual(config["dtype"], np.float64)
                 else:
                     # 'command list' is a list of strings
-                    self.assertEqual(config["dtype"].type, np.unicode_)
+                    self.assertEqual(config["dtype"].type, np.str_)
         else:
             self.assertEqual(output[1], {})
 

--- a/bapsflib/_hdf/maps/controls/tests/test_templates.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_templates.py
@@ -297,7 +297,7 @@ class TestControlTemplates(ut.TestCase):
                 "dset paths": configs_dict[config_name]["dset paths"],
                 "dset field": ("Command index",),
                 "shape": (),
-                "dtype": np.dtype((np.unicode_, 10)),
+                "dtype": np.dtype((np.str_, 10)),
             }
         }
         sv_dict = {

--- a/bapsflib/_hdf/utils/tests/test_hdfreadcontrol.py
+++ b/bapsflib/_hdf/utils/tests/test_hdfreadcontrol.py
@@ -367,7 +367,7 @@ class TestHDFReadControl(TestBase):
                             "dset paths": dset_paths,
                             "dset field": ("command",),
                             "shape": (),
-                            "dtype": np.dtype((np.unicode_, 10)),
+                            "dtype": np.dtype((np.str_, 10)),
                         },
                         "valid": {
                             "dset paths": dset_paths,

--- a/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
+++ b/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
@@ -1182,8 +1182,7 @@ class TestHDFReadData(TestBase):
 
         dset_arr = dset[indices, ...]
         if not keep_bits:
-            dset_arr = dset_arr.astype(np.float32)
-            dset_arr = (dv * dset_arr) - offset
+            dset_arr = np.astype((dv * dset_arr) - offset, np.float32)
 
         self.assertTrue(np.array_equal(data["signal"], dset_arr))
 

--- a/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
+++ b/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
@@ -1182,7 +1182,8 @@ class TestHDFReadData(TestBase):
 
         dset_arr = dset[indices, ...]
         if not keep_bits:
-            dset_arr = np.astype((dv * dset_arr) - offset, np.float32)
+            dset_arr = (dv * dset_arr) - offset
+            dset_arr = dset_arr.astype(np.float32)
 
         self.assertTrue(np.array_equal(data["signal"], dset_arr))
 

--- a/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
+++ b/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
@@ -1185,7 +1185,9 @@ class TestHDFReadData(TestBase):
             dset_arr = (dv * dset_arr) - offset
             dset_arr = dset_arr.astype(np.float32)
 
-        self.assertTrue(np.array_equal(data["signal"], dset_arr))
+        self.assertTrue(data["signal"].dtype == dset_arr.dtype)
+        self.assertTrue(data["signal"].shape == dset_arr.shape)
+        self.assertTrue(np.allclose(data["signal"], dset_arr))
 
     def assertDataInfo(self, data, _bf):
         """

--- a/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
+++ b/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
@@ -1187,7 +1187,7 @@ class TestHDFReadData(TestBase):
 
         self.assertTrue(data["signal"].dtype == dset_arr.dtype)
         self.assertTrue(data["signal"].shape == dset_arr.shape)
-        self.assertTrue(np.allclose(data["signal"], dset_arr))
+        self.assertTrue(np.allclose(data["signal"], dset_arr, rtol=5e-5))
 
     def assertDataInfo(self, data, _bf):
         """

--- a/changelog/136.pkg_management.rst
+++ b/changelog/136.pkg_management.rst
@@ -1,0 +1,1 @@
+Removed upper dependency limit on `numpy`, ``numpy < 2.0``.

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -3,5 +3,5 @@
 -r build.txt
 astropy >= 4.3.1
 h5py >= 3.0
-numpy >= 1.20, < 2.0
+numpy >= 1.20
 scipy >= 0.19

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     # ought to mirror requirements/install.txt
     astropy >= 4.3.1
     h5py >= 3.0
-    numpy >= 1.20, < 2.0
+    numpy >= 1.20
     scipy >= 0.19
 
 [options.extras_require]


### PR DESCRIPTION
Remove dependency restriction `numpy < 2.0`

To accomplish this the following was done:

* replaced `np.unicode_` with `np.str_`
* Updated `TestHDFReadData.assetDataArrayValues` to use `np.allclose()` instead of `np.array_equal`.  The latter was running into floating point rounding issues causing erroneous test failures.