### PR TITLE
Setup `sphinx-hoverxref`

### DIFF
--- a/changelog/139.doc.rst
+++ b/changelog/139.doc.rst
@@ -1,0 +1,2 @@
+Added `Sphinx <https://www.sphinx-doc.org>`_
+extension `sphinx-hoverxref <https://sphinx-hoverxref.readthedocs.io>`_.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ from bapsflib import __version__ as release
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "hoverxref.extension",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
@@ -57,6 +58,42 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
 }
+
+# Setup hoverxref
+hoverxref_intersphinx = list(intersphinx_mapping.keys())
+hoverxref_auto_ref = True
+hoverxref_domains = ["py", "cite"]
+hoverxref_mathjax = True
+hoverxref_roles = ["confval", "term"]
+hoverxref_sphinxtabs = True
+hoverxref_tooltip_maxwidth = 600  # RTD main window is 696px
+hoverxref_role_types = {
+    # roles with cite domain
+    "p": "tooltip",
+    "t": "tooltip",
+    # roles with py domain
+    "attr": "tooltip",
+    "class": "tooltip",
+    "const": "tooltip",
+    "data": "tooltip",
+    "exc": "tooltip",
+    "func": "tooltip",
+    "meth": "tooltip",
+    "mod": "tooltip",
+    "obj": "tooltip",
+    # roles with std domain
+    "confval": "tooltip",
+    "hoverxref": "tooltip",
+    "ref": "tooltip",
+    "term": "tooltip",
+}
+
+if building_on_readthedocs := os.environ.get("READTHEDOCS"):
+    # Using the proxied API endpoint is a Read the Docs strategy to
+    # avoid a cross-site request forgery block for docs using a custom
+    # domain. See conf.py for sphinx-hoverxref.
+    use_proxied_api_endpoint = os.environ.get("PROXIED_API_ENDPOINT")
+    hoverxref_api_host = "/_" if use_proxied_api_endpoint else "https://readthedocs.org"
 
 # Various sphinx configuration variables
 autoclass_content = "both"  # for classes insert docstrings from __init__ and class

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,15 +68,15 @@ intersphinx_mapping = {
 # Setup hoverxref
 hoverxref_intersphinx = list(intersphinx_mapping.keys())
 hoverxref_auto_ref = True
-hoverxref_domains = ["py", "cite"]
+hoverxref_domains = ["py"]  # ["py", "cite"]
 hoverxref_mathjax = True
 hoverxref_roles = ["confval", "term"]
 hoverxref_sphinxtabs = True
 hoverxref_tooltip_maxwidth = 600  # RTD main window is 696px
 hoverxref_role_types = {
     # roles with cite domain
-    "p": "tooltip",
-    "t": "tooltip",
+    # "p": "tooltip",
+    # "t": "tooltip",
     # roles with py domain
     "attr": "tooltip",
     "class": "tooltip",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,13 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "plasmapy": ("https://docs.plasmapy.org/en/latest/", None),
     "python": ("https://docs.python.org/3", None),
+    "readthedocs": ("https://docs.readthedocs.io/en/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
+    "sphinx_automodapi": (
+        "https://sphinx-automodapi.readthedocs.io/en/latest/",
+        None,
+    ),
 }
 
 # Setup hoverxref

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,5 +6,6 @@ sphinx >= 3.2.0, < 7.0
 sphinx-automodapi >= 0.13
 sphinx-changelog
 sphinx-gallery
+sphinx-hoverxref >= 1.3
 sphinx_rtd_theme
 towncrier == 22.8.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,7 +2,7 @@
 # ought to mirror 'docs' under options.extras_require in config.cfg
 -r install.txt
 packaging
-sphinx >= 3.2.0, < 7.0
+sphinx >= 3.2.0
 sphinx-automodapi >= 0.13
 sphinx-changelog
 sphinx-gallery

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ tests =
 docs =
     # ought to mirror requirements/docs.txt
     packaging
-    sphinx >= 3.2.0, < 7.0
+    sphinx >= 3.2.0
     sphinx-automodapi >= 0.13
     sphinx-changelog
     sphinx-gallery

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ docs =
     sphinx-automodapi >= 0.13
     sphinx-changelog
     sphinx-gallery
+    sphinx-hoverxref >= 1.3
     sphinx_rtd_theme
     towncrier == 22.8.0
 developer =


### PR DESCRIPTION
Setup the Sphinx extension [`sphinx-hoverxref`](https://sphinx-hoverxref.readthedocs.io/en/latest/)