### PR TITLE
Patch `isort-action` workflow

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,21 +19,23 @@ jobs:
       - name: Install isort
         run: |
           python -m pip install -r requirements/extras.txt
-          python -m pip install colorama
       - name: Retrieve isort version
         run: |
           ISORTVERSION=$(python -c "import isort; print(isort.__version__)")
           echo "ISORT_VERSION=${ISORTVERSION}" >> $GITHUB_ENV
+      - run: echo "isort[color]" >> /tmp/isort.requirements.txt
       - name: Which isort version
         uses: isort/isort-action@v1.1.0
         with:
-          isort-version: "${{ env.ISORT_VERSION }}"
+          isortVersion: "${{ env.ISORT_VERSION }}"
           configuration: "--version"
+          requirements-files: "/tmp/isort.requirements.txt"
       - name: Run isort checks
         uses: isort/isort-action@v1.1.0
         with:
-          isort-version: "${{ env.ISORT_VERSION }}"
+          isortVersion: "${{ env.ISORT_VERSION }}"
           configuration: "--check-only --diff --color"
+          requirements-files: "/tmp/isort.requirements.txt"
 
   black:
     runs-on: ubuntu-latest

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -23,7 +23,8 @@ jobs:
         run: |
           ISORTVERSION=$(python -c "import isort; print(isort.__version__)")
           echo "ISORT_VERSION=${ISORTVERSION}" >> $GITHUB_ENV
-      - run: echo "isort[color]" >> /tmp/isort.requirements.txt
+      - name: Create Temp Requirements file isort.requirements.txt
+        run: echo "colorama" >> /tmp/isort.requirements.txt
       - name: Which isort version
         uses: isort/isort-action@v1.1.0
         with:


### PR DESCRIPTION
This PR updates the `linters.yml` workflow, specifically the `isort-action` workflow.  `isort` started installing dependencies into their own virtual environment (https://github.com/isort/isort-action/pull/96), which prevent our `Install isort` step from properly setting up dependencies.