### PR TITLE
Update tests for control device mappings.

### DIFF
--- a/bapsflib/_hdf/maps/controls/tests/common.py
+++ b/bapsflib/_hdf/maps/controls/tests/common.py
@@ -14,6 +14,8 @@ import os
 import re
 import unittest as ut
 
+from typing import Type
+
 from bapsflib._hdf.maps import FauxHDFBuilder, MapTypes
 from bapsflib._hdf.maps.controls import ConType
 from bapsflib._hdf.maps.controls.templates import (
@@ -39,9 +41,10 @@ class ControlTestCase(ut.TestCase):
     #   raise a HDFMappingError
 
     f = NotImplemented
-    DEVICE_NAME = NotImplemented
-    DEVICE_PATH = NotImplemented
-    MAP_CLASS = NotImplemented
+    DEVICE_NAME = NotImplemented  # type: str
+    DEVICE_PATH = NotImplemented  # type: str
+    MAP_CLASS = NotImplemented  # type: Type[HDFMapControlTemplate]
+    CONTYPE = NotImplemented  # type: ConType
 
     @classmethod
     def setUpClass(cls):
@@ -92,6 +95,16 @@ class ControlTestCase(ut.TestCase):
 
     def test_maptype(self):
         self.assertTrue(self.MAP_CLASS._maptype == MapTypes.CONTROL)
+
+    def test_contype(self):
+        _conditions = [
+            self.MAP_CLASS._contype == self.CONTYPE,
+            self.map.contype == self.CONTYPE,
+            self.map.info["contype"] == self.map.contype,
+        ]
+        for condition in _conditions:
+            with self.subTest(condition=condition):
+                self.assertTrue(self.MAP_CLASS._contype == self.CONTYPE)
 
     def test_map_basics(self):
         """Test all required basic map features."""

--- a/bapsflib/_hdf/maps/controls/tests/common.py
+++ b/bapsflib/_hdf/maps/controls/tests/common.py
@@ -357,15 +357,13 @@ class ControlTestCase(ut.TestCase):
             self.assertIn("shape", sv_config)
             self.assertIn("dtype", sv_config)
 
-            # ['state values']['']['dset paths']
-            self.assertEqual(sv_config["dset paths"], config["dset paths"])
-
             # ['state values']['']['dset field']
             self.assertIsInstance(sv_config["dset field"], tuple)
-            self.assertNotEqual(len(sv_config["dset field"]), 0)
+            self.assertTrue(len(sv_config["dset field"]), 1)
             self.assertTrue(
                 all(isinstance(field, str) for field in sv_config["dset field"])
             )
+            self.assertTrue(sv_config["dset paths"][0] in config["dset paths"])
 
             # ['state values]['']['shape']
             self.assertIsInstance(sv_config["shape"], tuple)

--- a/bapsflib/_hdf/maps/controls/tests/common.py
+++ b/bapsflib/_hdf/maps/controls/tests/common.py
@@ -98,13 +98,13 @@ class ControlTestCase(ut.TestCase):
 
     def test_contype(self):
         _conditions = [
-            self.MAP_CLASS._contype == self.CONTYPE,
-            self.map.contype == self.CONTYPE,
-            self.map.info["contype"] == self.map.contype,
+            (self.MAP_CLASS._contype, self.CONTYPE),
+            (self.map.contype, self.CONTYPE),
+            (self.map.info["contype"], self.map.contype),
         ]
-        for condition in _conditions:
-            with self.subTest(condition=condition):
-                self.assertTrue(self.MAP_CLASS._contype == self.CONTYPE)
+        for c1, c2 in _conditions:
+            with self.subTest(c1=c1, c2=c2):
+                self.assertEqual(c1, c2)
 
     def test_map_basics(self):
         """Test all required basic map features."""

--- a/bapsflib/_hdf/maps/controls/tests/common.py
+++ b/bapsflib/_hdf/maps/controls/tests/common.py
@@ -239,7 +239,11 @@ class ControlTestCase(ut.TestCase):
             self.assertIn("dtype", config["shotnum"])
 
             # ['shotnum']['dset paths']
-            self.assertEqual(config["shotnum"]["dset paths"], config["dset paths"])
+            sn_dset_paths = config["shotnum"]["dset paths"]
+            self.assertTrue(sn_dset_paths is None or isinstance(sn_dset_paths, tuple))
+            if isinstance(sn_dset_paths, tuple):
+                self.assertTrue(len(sn_dset_paths) == 1)
+                self.assertTrue(sn_dset_paths[0] in config["dset paths"])
 
             # ['shotnum']['dset field']
             self.assertIsInstance(config["shotnum"]["dset field"], tuple)

--- a/bapsflib/_hdf/maps/controls/tests/test_n5700ps.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_n5700ps.py
@@ -30,15 +30,13 @@ class TestN5700PS(ControlTestCase):
     DEVICE_NAME = "N5700_PS"
     DEVICE_PATH = "Raw data + config/N5700_PS"
     MAP_CLASS = HDFMapControlN5700PS
+    CONTYPE = ConType.POWER
 
     def setUp(self):
         super().setUp()
 
     def tearDown(self):
         super().tearDown()
-
-    def test_contype(self):
-        self.assertEqual(self.map.info["contype"], ConType.POWER)
 
     def test_map_failures(self):
         """Test conditions that result in unsuccessful mappings."""

--- a/bapsflib/_hdf/maps/controls/tests/test_n5700ps.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_n5700ps.py
@@ -32,12 +32,6 @@ class TestN5700PS(ControlTestCase):
     MAP_CLASS = HDFMapControlN5700PS
     CONTYPE = ConType.POWER
 
-    def setUp(self):
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-
     def test_map_failures(self):
         """Test conditions that result in unsuccessful mappings."""
         # any failed build must throw a HDFMappingError

--- a/bapsflib/_hdf/maps/controls/tests/test_nixyz.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_nixyz.py
@@ -31,12 +31,6 @@ class TestNIXYZ(ControlTestCase):
     MAP_CLASS = HDFMapControlNIXYZ
     CONTYPE = ConType.MOTION
 
-    def setUp(self):
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-
     def test_map_failures(self):
         """Test conditions that result in unsuccessful mappings."""
         # any failed build must throw a HDFMappingError

--- a/bapsflib/_hdf/maps/controls/tests/test_nixyz.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_nixyz.py
@@ -29,15 +29,13 @@ class TestNIXYZ(ControlTestCase):
     DEVICE_NAME = "NI_XYZ"
     DEVICE_PATH = "Raw data + config/NI_XYZ"
     MAP_CLASS = HDFMapControlNIXYZ
+    CONTYPE = ConType.MOTION
 
     def setUp(self):
         super().setUp()
 
     def tearDown(self):
         super().tearDown()
-
-    def test_contype(self):
-        self.assertEqual(self.map.info["contype"], ConType.MOTION)
 
     def test_map_failures(self):
         """Test conditions that result in unsuccessful mappings."""

--- a/bapsflib/_hdf/maps/controls/tests/test_nixz.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_nixz.py
@@ -28,15 +28,13 @@ class TestNIXZ(ControlTestCase):
     DEVICE_NAME = "NI_XZ"
     DEVICE_PATH = "Raw data + config/NI_XZ"
     MAP_CLASS = HDFMapControlNIXZ
+    CONTYPE = ConType.MOTION
 
     def setUp(self):
         super().setUp()
 
     def tearDown(self):
         super().tearDown()
-
-    def test_contype(self):
-        self.assertEqual(self.map.info["contype"], ConType.MOTION)
 
     def test_map_failures(self):
         """Test conditions that result in unsuccessful mappings."""

--- a/bapsflib/_hdf/maps/controls/tests/test_nixz.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_nixz.py
@@ -30,12 +30,6 @@ class TestNIXZ(ControlTestCase):
     MAP_CLASS = HDFMapControlNIXZ
     CONTYPE = ConType.MOTION
 
-    def setUp(self):
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-
     def test_map_failures(self):
         """Test conditions that result in unsuccessful mappings."""
         # any failed build must throw a HDFMappingError

--- a/bapsflib/_hdf/maps/controls/tests/test_sixk.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_sixk.py
@@ -33,12 +33,6 @@ class TestSixK(ControlTestCase):
     MAP_CLASS = HDFMapControl6K
     CONTYPE = ConType.MOTION
 
-    def setUp(self):
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-
     def test_map_failures(self):
         """Test conditions that result in unsuccessful mappings."""
         # any failed build must throw a HDFMappingError

--- a/bapsflib/_hdf/maps/controls/tests/test_sixk.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_sixk.py
@@ -31,15 +31,13 @@ class TestSixK(ControlTestCase):
     DEVICE_NAME = "6K Compumotor"
     DEVICE_PATH = "Raw data + config/6K Compumotor"
     MAP_CLASS = HDFMapControl6K
+    CONTYPE = ConType.MOTION
 
     def setUp(self):
         super().setUp()
 
     def tearDown(self):
         super().tearDown()
-
-    def test_contype(self):
-        self.assertEqual(self.map.info["contype"], ConType.MOTION)
 
     def test_map_failures(self):
         """Test conditions that result in unsuccessful mappings."""

--- a/bapsflib/_hdf/maps/controls/tests/test_waveform.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_waveform.py
@@ -30,15 +30,13 @@ class TestWaveform(ControlTestCase):
     DEVICE_NAME = "Waveform"
     DEVICE_PATH = "Raw data + config/Waveform"
     MAP_CLASS = HDFMapControlWaveform
+    CONTYPE = ConType.WAVEFORM
 
     def setUp(self):
         super().setUp()
 
     def tearDown(self):
         super().tearDown()
-
-    def test_contype(self):
-        self.assertEqual(self.map.info["contype"], ConType.WAVEFORM)
 
     def test_map_failures(self):
         """Test conditions that result in unsuccessful mappings."""

--- a/bapsflib/_hdf/maps/controls/tests/test_waveform.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_waveform.py
@@ -32,12 +32,6 @@ class TestWaveform(ControlTestCase):
     MAP_CLASS = HDFMapControlWaveform
     CONTYPE = ConType.WAVEFORM
 
-    def setUp(self):
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-
     def test_map_failures(self):
         """Test conditions that result in unsuccessful mappings."""
         # any failed build must throw a HDFMappingError


### PR DESCRIPTION
This PR updates several tests to reflect changes made in PR #141.

- Add a test method `ControlTestCase.test_contype`.  This ensures the `contype` class attribute is properly tested if the specific control device tests inherit from `ControlTestCase`.
- Redundant methods or removed from specific control device tests.
- `ControlTestCase.assertConrolMapBasics()` is updated to allow `config['shotnum']['dset paths']` to be `None`.
- `ControlTestCase.assertSVConfig()` is updated to allow (and ensure) `config['state values'][<key>]['dset paths']` is a subset of `config['dset paths']`.