### PR TITLE
Overhaul functionality in `bapsflib._hdf.utils.helpers.py`

### DIFF
--- a/bapsflib/_hdf/utils/hdfreadcontrols.py
+++ b/bapsflib/_hdf/utils/hdfreadcontrols.py
@@ -267,7 +267,6 @@ class HDFReadControls(np.ndarray):
         # perform `shotnum` conditioning
         # - `shotnum` is returned as a numpy array
         shotnum = condition_shotnum(shotnum, cdset_dict, shotnumkey_dict)
-        print(shotnum)
 
         # ---- Build `index` and `sni` arrays for each dataset      ----
         #

--- a/bapsflib/_hdf/utils/hdfreadcontrols.py
+++ b/bapsflib/_hdf/utils/hdfreadcontrols.py
@@ -35,12 +35,12 @@ from bapsflib._hdf.utils.helpers import (
     condition_controls,
     condition_shotnum,
     do_shotnum_intersection,
+    IndexDict,
 )
 from bapsflib.utils.warnings import BaPSFWarning, HDFMappingWarning
 
 # define type aliases
 ControlsType = Union[str, Iterable[Union[str, Tuple[str, Any]]]]
-IndexDict = Dict[str, np.ndarray]
 
 
 class HDFReadControls(np.ndarray):

--- a/bapsflib/_hdf/utils/hdfreadcontrols.py
+++ b/bapsflib/_hdf/utils/hdfreadcontrols.py
@@ -248,11 +248,21 @@ class HDFReadControls(np.ndarray):
             config_name = control[1]
 
             # gather control datasets and shotnumkey's
-            cdset_path = cmap.configs[cconfn]["dset paths"][0]
-            cdset_dict[cname] = hdf_file.get(cdset_path)
-            shotnumkey = cmap.configs[cconfn]["shotnum"]["dset field"][0]
-            shotnumkey_dict[cname] = shotnumkey
             cmap = _fmap.controls[control_name]
+            control_config = cmap.configs[config_name]
+
+            if control_config["shotnum"]["dset paths"] is None:
+                # state values have differing dset paths and shotnum
+                # is pulled from those paths
+                for _key, _entry in control_config["state values"].items():
+                    _name = f"{control_name} - {_key}"
+                    cdset_dict[_name] = hdf_file.get(_entry["dset paths"][0])
+                    shotnumkey_dict[_name] = control_config["shotnum"]["dset field"][0]
+            else:
+                cdset_dict[control_name] = hdf_file.get(
+                    control_config["shotnum"]["dset paths"][0]
+                )
+                shotnumkey_dict[control_name] = control_config["shotnum"]["dset field"][0]
 
         # perform `shotnum` conditioning
         # - `shotnum` is returned as a numpy array

--- a/bapsflib/_hdf/utils/hdfreadcontrols.py
+++ b/bapsflib/_hdf/utils/hdfreadcontrols.py
@@ -122,25 +122,26 @@ class HDFReadControls(np.ndarray):
             configuration name (if more than one configuration exists)
 
         shotnum : Union[int, List[int], slice, numpy.ndarray], optional
-            HDF5 file shot number(s) indicating data entries to be extracted
+            HDF5 file shot number(s) indicating data entries to be
+            extracted
 
         intersection_set : `bool`, optional
             `True` (DEFAULT) will force the returned shot numbers to be
-            the intersection of :data:`shotnum` and the shot numbers
+            the intersection of ``shotnum`` and the shot numbers
             contained in each control device dataset. `False` will
             return the union instead of the intersection
 
         Notes
         -----
-        Behavior of :data:`shotnum` and :data:`intersection_set`:
-            * :data:`shotnum` indexing starts at 1
-            * Any :data:`shotnum` values `<= 0` will be thrown out.
-            * If `intersection_set=True`, then only data corresponding
-              to shot numbers that are specified in :data:`shotnum` and
+        Behavior of ``shotnum`` and ``intersection_set``:
+            * ``shotnum`` indexing starts at 1
+            * Any ``shotnum`` values ``<= 0`` will be thrown out.
+            * If ``intersection_set=True``, then only data corresponding
+              to shot numbers that are specified in ``shotnum`` and
               are in all control datasets will be returned.
             * If ``intersection_set=False``, then the returned array
               will have entries for all shot numbers specified in
-              :data:`shotnum` but entries that correspond to control
+              ``shotnum`` but entries that correspond to control
               datasets that do not have the specified shot number will
               be given a NULL value of ``-99999``, ``0``, `numpy.nan`,
               or ``''``, depending on the `numpy.dtype`.

--- a/bapsflib/_hdf/utils/hdfreaddata.py
+++ b/bapsflib/_hdf/utils/hdfreaddata.py
@@ -457,10 +457,10 @@ class HDFReadData(np.ndarray):
             # perform intersection
             if intersection_set:
                 shotnum, sni_dict, index_dict = do_shotnum_intersection(
-                    shotnum, {"digi": sni}, {"digi": index}
+                    shotnum, {"digi": {"signal": sni}}, {"digi": {"signal": index}}
                 )
-                sni = sni_dict["digi"]
-                index = index_dict["digi"]
+                sni = sni_dict["digi"]["signal"]
+                index = index_dict["digi"]["signal"]
 
             # print execution timing
             if timeit:  # pragma: no cover

--- a/bapsflib/_hdf/utils/hdfreaddata.py
+++ b/bapsflib/_hdf/utils/hdfreaddata.py
@@ -442,7 +442,7 @@ class HDFReadData(np.ndarray):
             """
             # perform `shotnum` conditioning
             # - `shotnum` is returned as a numpy array
-            shotnum = condition_shotnum(shotnum, {"digi": dheader}, {"digi": shotnumkey})
+            shotnum = condition_shotnum(shotnum, [dheader], [shotnumkey])
 
             # Calc. the corresponding `index` and `sni`
             # - `shotnum` will be converted from list to np.array

--- a/bapsflib/_hdf/utils/hdfreaddata.py
+++ b/bapsflib/_hdf/utils/hdfreaddata.py
@@ -452,7 +452,11 @@ class HDFReadData(np.ndarray):
                 condition_shotnum(shotnum, dheader, shotnumkey,
                                   intersection_set)
             """
-            index, sni = build_sndr_for_simple_dset(shotnum, dheader, shotnumkey)
+            index, sni = build_sndr_for_simple_dset(
+                shotnum=shotnum,
+                dset=dheader,
+                shotnumkey=shotnumkey,
+            )
 
             # perform intersection
             if intersection_set:

--- a/bapsflib/_hdf/utils/helpers.py
+++ b/bapsflib/_hdf/utils/helpers.py
@@ -411,9 +411,8 @@ def build_sndr_for_complex_dset(
 
 def condition_controls(hdf_file: File, controls: Any) -> List[Tuple[str, Any]]:
     """
-    Conditions the **controls** argument for
-    :class:`~.hdfreadcontrols.HDFReadControls` and
-    :class:`~.hdfreaddata.HDFReadData`.
+    Conditions the ``controls`` argument for
+    `~.hdfreadcontrols.HDFReadControls` and `~.hdfreaddata.HDFReadData`.
 
     Parameters
     ----------
@@ -441,7 +440,7 @@ def condition_controls(hdf_file: File, controls: Any) -> List[Tuple[str, Any]]:
 
     .. admonition:: Condition Criteria
 
-        #. Input **controls** should be
+        #. Input ``controls`` should be
            ``Union[str, Iterable[Union[str, Tuple[str, Any]]]]``
         #. There can only be one control for each
            :class:`~bapsflib._hdf.maps.controls.types.ConType`.
@@ -546,7 +545,7 @@ def condition_shotnum(
     Parameters
     ----------
     shotnum: :term:`array_like` or Union[int, slice, List[int,...]]
-        desired HDF5 shot numbers
+        Array like object of desired shot numbers.
 
     dset_list : List[h5py.Dataset]
         List of control dataset instances that the shot number
@@ -609,126 +608,6 @@ def condition_shotnum(
     elif isinstance(shotnum, slice):
         # determine the largest possible shot number
         last_sn = [dset[-1, key] + 1 for dset, key in zip(dset_list, shotnumkey_list)]
-        if shotnum.stop is not None:
-            last_sn.append(shotnum.stop)
-        stop_sn = max(last_sn)
-
-        # get the start, stop, and step for the shot number array
-        start, stop, step = shotnum.indices(stop_sn)
-
-        # re-define `shotnum`
-        shotnum = np.arange(start, stop, step, dtype=np.int32)
-
-        # remove shot numbers <= 0
-        shotnum = np.delete(shotnum, np.where(shotnum <= 0)[0])
-        shotnum = shotnum.astype(np.uint32)
-
-        # ensure not NULL
-        if shotnum.size == 0:
-            raise ValueError("Valid `shotnum` not passed. Resulting array would be NULL")
-
-    elif isinstance(shotnum, np.ndarray):
-        if shotnum.ndim != 1:
-            shotnum = shotnum.squeeze()
-        if (
-            shotnum.ndim != 1
-            or not np.issubdtype(shotnum.dtype, np.integer)
-            or bool(shotnum.dtype.names)
-        ):
-            raise ValueError("Valid `shotnum` not passed")
-
-        # remove shot numbers <= 0
-        shotnum.sort()
-        shotnum = np.delete(shotnum, np.where(shotnum <= 0)[0])
-        shotnum = shotnum.astype(np.uint32)
-
-        # ensure not NULL
-        if shotnum.size == 0:
-            raise ValueError("Valid `shotnum` not passed. Resulting array would be NULL")
-    else:
-        raise ValueError("Valid `shotnum` not passed")
-
-    # return
-    return shotnum
-
-
-def _condition_shotnum(
-    shotnum: Any, dset_dict: Dict[str, h5py.Dataset], shotnumkey_dict: Dict[str, str]
-) -> np.ndarray:
-    r"""
-    Conditions the **shotnum** argument for
-    :class:`~bapsflib._hdf.utils.hdfreadcontrols.HDFReadControls` and
-    :class:`~bapsflib._hdf.utils.hdfreaddata.HDFReadData`.
-
-    Parameters
-    ----------
-    shotnum: :term:`array_like`
-        desired HDF5 shot numbers
-
-    dset_dict : Dict[str, h5py.Dataset]
-        dictionary of all control dataset instances
-
-    shotnumkey_dict : Dict[str, str]
-        dictionary of the shot number field name for each control
-        dataset in dset_dict
-
-    Returns
-    -------
-    `numpy.ndarray`
-        conditioned ``shotnum`` numpy array
-
-
-    .. admonition:: Condition Criteria
-
-        #. Input **shotnum** should be
-           ``Union[int, List[int,...], slice, np.ndarray]``
-        #. Any :math:`\mathbf{shotnum} \le 0` will be removed.
-        #. A `ValueError` will be thrown if the conditioned array is
-           NULL.
-    """
-    # Acceptable `shotnum` types
-    # 1. int
-    # 2. slice() object
-    # 3. List[int, ...]
-    # 4. np.array (dtype = np.integer and ndim = 1)
-    #
-    # Catch each `shotnum` type and convert to numpy array
-    #
-    if isinstance(shotnum, int):
-        if shotnum <= 0 or isinstance(shotnum, bool):
-            raise ValueError(
-                f"Valid `shotnum` ({shotnum}) not passed. Resulting array would be NULL."
-            )
-
-        # convert
-        shotnum = np.array([shotnum], dtype=np.uint32)
-
-    elif isinstance(shotnum, list):
-        # ensure all elements are int
-        if not all(isinstance(sn, int) for sn in shotnum):
-            raise ValueError("Valid `shotnum` not passed. All values NOT int.")
-
-        # remove shot numbers <= 0
-        shotnum.sort()
-        shotnum = list(set(shotnum))
-        shotnum.sort()
-        if min(shotnum) <= 0:
-            # remove values less-than or equal to 0
-            new_sn = [sn for sn in shotnum if sn > 0]
-            shotnum = new_sn
-
-        # ensure not NULL
-        if len(shotnum) == 0:
-            raise ValueError("Valid `shotnum` not passed. Resulting array would be NULL")
-
-        # convert
-        shotnum = np.array(shotnum, dtype=np.uint32)
-
-    elif isinstance(shotnum, slice):
-        # determine the largest possible shot number
-        last_sn = [
-            dset_dict[cname][-1, shotnumkey_dict[cname]] + 1 for cname in dset_dict
-        ]
         if shotnum.stop is not None:
             last_sn.append(shotnum.stop)
         stop_sn = max(last_sn)

--- a/bapsflib/_hdf/utils/helpers.py
+++ b/bapsflib/_hdf/utils/helpers.py
@@ -326,7 +326,7 @@ def build_sndr_for_complex_dset(
                 # and, thus, the routines assumption's do not match
                 # the format of the dataset
                 raise ValueError(
-                    "The specified dataset is NOT consistent with the"
+                    "The specified dataset is NOT consistent with the "
                     "routines assumptions of a complex dataset"
                 )
     else:
@@ -345,7 +345,7 @@ def build_sndr_for_complex_dset(
             # are found or the routine's assumptions do not
             # match the format of the dataset
             raise ValueError(
-                "The specified dataset is NOT consistent with the"
+                "The specified dataset is NOT consistent with the "
                 "routines assumptions of a complex dataset"
             )
 

--- a/bapsflib/_hdf/utils/helpers.py
+++ b/bapsflib/_hdf/utils/helpers.py
@@ -45,17 +45,17 @@ def build_shotnum_dset_relation(
     config_name: str,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """
-    Compares the **shotnum** `numpy` array to the specified dataset,
-    **dset**, to determine which indices contain the desired shot
+    Compares the ``shotnum`` `numpy` array to the specified dataset,
+    ``dset``, to determine which indices contain the desired shot
     number(s)
-    [for :class:`~bapsflib._hdf.utils.hdfreadcontrols.HDFReadControls`].
+    [for `~bapsflib._hdf.utils.hdfreadcontrols.HDFReadControls`].
     As a results, two numpy arrays are returned which satisfy the rule::
 
         shotnum[sni] = dset[index, shotnumkey]
 
-    where **shotnum** is the original shot number array, **sni** is a
-    boolean numpy array masking which shot numbers were determined to
-    be in the dataset, and **index** is an array of indices
+    where ``shotnum`` is the original shot number array, ``sni`` is a
+    boolean `numpy` array masking which shot numbers were determined to
+    be in the dataset, and ``index`` is an array of indices
     corresponding to the desired shot number(s).
 
     Parameters

--- a/bapsflib/_hdf/utils/helpers.py
+++ b/bapsflib/_hdf/utils/helpers.py
@@ -26,11 +26,6 @@ import numpy as np
 
 from typing import Any, Dict, Iterable, List, Tuple, Union
 
-from bapsflib._hdf.maps.controls.templates import (
-    ControlMap,
-    HDFMapControlCLTemplate,
-    HDFMapControlTemplate,
-)
 from bapsflib._hdf.utils.file import File
 
 # define type aliases

--- a/bapsflib/_hdf/utils/helpers.py
+++ b/bapsflib/_hdf/utils/helpers.py
@@ -122,14 +122,14 @@ def build_sndr_for_simple_dset(
     shotnum: np.ndarray, dset: h5py.Dataset, shotnumkey: str
 ) -> Tuple[np.ndarray, np.ndarray]:
     """
-    Compares the **shotnum** numpy array to the specified "simple"
+    Compares the ``shotnum`` numpy array to the specified "simple"
     dataset, **dset**, to determine which indices contain the desired
     shot number(s).  As a results, two numpy arrays are returned which
     satisfy the rule::
 
         shotnum[sni] = dset[index, shotnumkey]
 
-    where **shotnum** is the original shot number array, **sni** is a
+    where ``shotnum`` is the original shot number array, **sni** is a
     boolean numpy array masking which shot numbers were determined to
     be in the dataset, and **index** is an array of indices
     corresponding to the desired shot number(s).
@@ -140,14 +140,13 @@ def build_sndr_for_simple_dset(
     Parameters
     ----------
     shotnum : :term:`array_like`
-        desired HDF5 shot number
+        Array like object of desired shot numbers.
 
     dset : `h5py.Dataset`
-        dataset containing shot numbers
+        Control device dataset
 
     shotnumkey : `str`
-        field name in the dataset that contains
-        the shot numbers
+        Dataset field name containing shot numbers.
 
     Returns
     -------

--- a/bapsflib/_hdf/utils/helpers.py
+++ b/bapsflib/_hdf/utils/helpers.py
@@ -697,7 +697,6 @@ def do_shotnum_intersection(
     """
     # intersect shot numbers
     shotnum_intersect = shotnum
-    # for sni in sni_dict.values():
     for control_name in sni_dict.keys():
         for state_key, sni in sni_dict[control_name].items():
             shotnum_intersect = np.intersect1d(
@@ -707,7 +706,6 @@ def do_shotnum_intersection(
         raise ValueError("Input `shotnum` would result in a NULL array")
 
     # now filter
-    # for control_name in index_dict:
     for control_name in index_dict.keys():
         for state_key, index in index_dict[control_name].items():
             sni = sni_dict[control_name][state_key]

--- a/bapsflib/_hdf/utils/helpers.py
+++ b/bapsflib/_hdf/utils/helpers.py
@@ -542,24 +542,25 @@ def condition_controls(hdf_file: File, controls: Any) -> List[Tuple[str, Any]]:
 
 
 def condition_shotnum(
-    shotnum: Any, dset_dict: Dict[str, h5py.Dataset], shotnumkey_dict: Dict[str, str]
+    shotnum: Any, dset_list: List[h5py.Dataset], shotnumkey_list: List[str]
 ) -> np.ndarray:
     r"""
-    Conditions the **shotnum** argument for
-    :class:`~bapsflib._hdf.utils.hdfreadcontrols.HDFReadControls` and
-    :class:`~bapsflib._hdf.utils.hdfreaddata.HDFReadData`.
+    Conditions the ``shotnum`` argument for
+    `~bapsflib._hdf.utils.hdfreadcontrols.HDFReadControls` and
+    :`~bapsflib._hdf.utils.hdfreaddata.HDFReadData`.
 
     Parameters
     ----------
-    shotnum: :term:`array_like`
+    shotnum: :term:`array_like` or Union[int, slice, List[int,...]]
         desired HDF5 shot numbers
 
-    dset_dict : Dict[str, h5py.Dataset]
-        dictionary of all control dataset instances
+    dset_list : List[h5py.Dataset]
+        List of control dataset instances that the shot number
+        ``shotnum`` should be conditioned against
 
-    shotnumkey_dict : Dict[str, str]
-        dictionary of the shot number field name for each control
-        dataset in dset_dict
+    shotnumkey_list : List[str]
+        A one-to-one list with ``dset_list`` that names the shot number
+        column filed in the associated dataset.
 
     Returns
     -------
@@ -569,8 +570,6 @@ def condition_shotnum(
 
     .. admonition:: Condition Criteria
 
-        #. Input **shotnum** should be
-           ``Union[int, List[int,...], slice, np.ndarray]``
         #. Any :math:`\mathbf{shotnum} \le 0` will be removed.
         #. A `ValueError` will be thrown if the conditioned array is
            NULL.
@@ -614,10 +613,8 @@ def condition_shotnum(
         shotnum = np.array(shotnum, dtype=np.uint32)
 
     elif isinstance(shotnum, slice):
-        # determine largest possible shot number
-        last_sn = [
-            dset_dict[cname][-1, shotnumkey_dict[cname]] + 1 for cname in dset_dict
-        ]
+        # determine the largest possible shot number
+        last_sn = [dset[-1, key] + 1 for dset, key in zip(dset_list, shotnumkey_list)]
         if shotnum.stop is not None:
             last_sn.append(shotnum.stop)
         stop_sn = max(last_sn)

--- a/bapsflib/_hdf/utils/helpers.py
+++ b/bapsflib/_hdf/utils/helpers.py
@@ -42,7 +42,7 @@ def build_shotnum_dset_relation(
     dset: h5py.Dataset,
     shotnumkey: str,
     cmap: ControlMap,
-    cconfn: Any,
+    config_name: str,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """
     Compares the **shotnum** `numpy` array to the specified dataset,
@@ -73,7 +73,7 @@ def build_shotnum_dset_relation(
     cmap : `ControlMap`
         mapping object for control device
 
-    cconfn :
+    config_name : str
         configuration name for the control device
 
     Returns
@@ -97,7 +97,7 @@ def build_shotnum_dset_relation(
     # dset         - the control device dataset
     # shotnumkey   - field name for the shot number column in dset
     # cmap         - file mapping object for the control device
-    # cconfn       - configuration for control device
+    # config_name       - configuration for control device
     #
     # Returns:
     # index     np.array(dtype=uint32)  - dset row index for the
@@ -113,7 +113,13 @@ def build_shotnum_dset_relation(
         index, sni = build_sndr_for_simple_dset(shotnum, dset, shotnumkey)
     else:
         # the dataset saves data for multiple configurations
-        index, sni = build_sndr_for_complex_dset(shotnum, dset, shotnumkey, cmap, cconfn)
+        index, sni = build_sndr_for_complex_dset(
+            shotnum,
+            dset,
+            shotnumkey,
+            cmap,
+            config_name,
+        )
 
     # return calculated arrays
     return index.view(), sni.view()

--- a/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
+++ b/bapsflib/_hdf/utils/tests/test_hdfreaddata.py
@@ -23,11 +23,11 @@ from bapsflib._hdf.maps import HDFMapper
 from bapsflib._hdf.maps.digitizers.sis3301 import HDFMapDigiSIS3301
 from bapsflib._hdf.utils.file import File
 from bapsflib._hdf.utils.hdfreadcontrols import HDFReadControls
-from bapsflib._hdf.utils.hdfreaddata import (
+from bapsflib._hdf.utils.hdfreaddata import HDFReadData
+from bapsflib._hdf.utils.helpers import (
     build_sndr_for_simple_dset,
     condition_shotnum,
     do_shotnum_intersection,
-    HDFReadData,
 )
 from bapsflib._hdf.utils.tests import TestBase
 from bapsflib.utils.decorators import with_bf

--- a/bapsflib/_hdf/utils/tests/test_helpers.py
+++ b/bapsflib/_hdf/utils/tests/test_helpers.py
@@ -122,11 +122,11 @@ class TestBuildShotnumDsetRelation(TestBase):
         cdset = self.cgroup["Run time list"]
         with self.assertRaises(ValueError):
             build_shotnum_dset_relation(
-                np.empty(5, dtype=np.uint32),
-                cdset,
-                "Shot number",
-                self.map,
-                "config01",
+                shotnum=np.empty(5, dtype=np.uint32),
+                dset=cdset,
+                shotnumkey="Shot number",
+                n_configs=len(self.map.configs),
+                config_id="config01",
             )
 
     def assertInRangeSN(self):
@@ -154,7 +154,11 @@ class TestBuildShotnumDsetRelation(TestBase):
             sn_arr = np.array(og_shotnum, dtype=np.uint32)
             for cconfn in self.map.configs:
                 index, sni = build_shotnum_dset_relation(
-                    sn_arr, cdset, shotnumkey, self.map, cconfn
+                    shotnum=sn_arr,
+                    dset=cdset,
+                    shotnumkey=shotnumkey,
+                    n_configs=len(self.map.configs),
+                    config_id=cconfn,
                 )
 
                 self.assertSNSuite(
@@ -192,7 +196,11 @@ class TestBuildShotnumDsetRelation(TestBase):
             sn_arr = np.array(og_shotnum, dtype=np.uint32)
             for cconfn in self.map.configs:
                 index, sni = build_shotnum_dset_relation(
-                    sn_arr, cdset, shotnumkey, self.map, cconfn
+                    shotnum=sn_arr,
+                    dset=cdset,
+                    shotnumkey=shotnumkey,
+                    n_configs=len(self.map.configs),
+                    config_id=cconfn,
                 )
 
                 self.assertSNSuite(

--- a/bapsflib/_hdf/utils/tests/test_helpers.py
+++ b/bapsflib/_hdf/utils/tests/test_helpers.py
@@ -21,7 +21,7 @@ from bapsflib._hdf.utils.file import File
 from bapsflib._hdf.utils.helpers import (
     build_shotnum_dset_relation,
     condition_controls,
-    _condition_shotnum,
+    condition_shotnum,
     do_shotnum_intersection,
 )
 from bapsflib._hdf.utils.tests import TestBase
@@ -544,12 +544,12 @@ class TestConditionShotnum(TestBase):
         sn = [-20, 0]
         for shotnum in sn:
             with self.assertRaises(ValueError):
-                _sn = _condition_shotnum(shotnum, {}, {})
+                _sn = condition_shotnum(shotnum, [], [])
 
         # shotnum > 0 (valid)
         sn = [1, 100]
         for shotnum in sn:
-            _sn = _condition_shotnum(shotnum, {}, {})
+            _sn = condition_shotnum(shotnum, [], [])
 
             self.assertIsInstance(_sn, np.ndarray)
             self.assertEqual(_sn.shape, (1,))
@@ -564,7 +564,7 @@ class TestConditionShotnum(TestBase):
         ]
         for shotnum in sn:
             with self.assertRaises(ValueError):
-                _sn = _condition_shotnum(shotnum, {}, {})
+                _sn = condition_shotnum(shotnum, [], [])
 
         # all shotnum values are <= 0
         sn = [
@@ -573,7 +573,7 @@ class TestConditionShotnum(TestBase):
         ]
         for shotnum in sn:
             with self.assertRaises(ValueError):
-                _sn = _condition_shotnum(shotnum, {}, {})
+                _sn = condition_shotnum(shotnum, [], [])
 
         # valid shotnum lists
         sn = [
@@ -582,7 +582,7 @@ class TestConditionShotnum(TestBase):
             ([1, 2, 4], np.array([1, 2, 4], dtype=np.uint32)),
         ]
         for shotnum, ex_sn in sn:
-            _sn = _condition_shotnum(shotnum, {}, {})
+            _sn = condition_shotnum(shotnum, [], [])
 
             self.assertIsInstance(_sn, np.ndarray)
             self.assertTrue(np.array_equal(_sn, ex_sn))
@@ -597,18 +597,12 @@ class TestConditionShotnum(TestBase):
         self.f.create_dataset("d2", data=data)
 
         # make fake dicts
-        dset_dict = {
-            "c1": self.f["d1"],
-            "c2": self.f["d2"],
-        }
-        shotnumkey_dict = {
-            "c1": "Shot number",
-            "c2": "Shot number",
-        }
+        dset_list = [self.f["d1"], self.f["d2"]]
+        shotnumkey_list = ["Shot number", "Shot number"]
 
         # invalid shotnum slices (creates NULL arrays)
         with self.assertRaises(ValueError):
-            _sn = _condition_shotnum(slice(-1, -4, 1), dset_dict, shotnumkey_dict)
+            _sn = condition_shotnum(slice(-1, -4, 1), dset_list, shotnumkey_list)
 
         # valid shotnum slices
         sn = [
@@ -619,7 +613,7 @@ class TestConditionShotnum(TestBase):
             (slice(-2, -1), np.array([6], dtype=np.uint32)),
         ]
         for shotnum, ex_sn in sn:
-            _sn = _condition_shotnum(shotnum, dset_dict, shotnumkey_dict)
+            _sn = condition_shotnum(shotnum, dset_list, shotnumkey_list)
 
             self.assertIsInstance(_sn, np.ndarray)
             self.assertTrue(np.array_equal(_sn, ex_sn))
@@ -644,7 +638,7 @@ class TestConditionShotnum(TestBase):
         ]
         for shotnum in sn:
             with self.assertRaises(ValueError):
-                _sn = _condition_shotnum(shotnum, {}, {})
+                _sn = condition_shotnum(shotnum, [], [])
 
         # shotnum valid
         sn = [
@@ -653,7 +647,7 @@ class TestConditionShotnum(TestBase):
             (np.array([20, 30], np.int32), np.array([20, 30], np.uint32)),
         ]
         for shotnum, ex_sn in sn:
-            _sn = _condition_shotnum(shotnum, {}, {})
+            _sn = condition_shotnum(shotnum, [], [])
 
             self.assertIsInstance(_sn, np.ndarray)
             self.assertTrue(np.array_equal(_sn, ex_sn))
@@ -663,7 +657,7 @@ class TestConditionShotnum(TestBase):
         sn = [1.5, None, True, {}]
         for shotnum in sn:
             with self.assertRaises(ValueError):
-                _sn = _condition_shotnum(shotnum, {}, {})
+                _sn = condition_shotnum(shotnum, [], [])
 
 
 class TestDoShotnumIntersection(ut.TestCase):
@@ -673,34 +667,37 @@ class TestDoShotnumIntersection(ut.TestCase):
         """Test intersection behavior with one control device"""
         # test a case that results in a null result
         shotnum = np.arange(1, 21, 1, dtype=np.uint32)
-        sni_dict = {"Waveform": np.zeros(shotnum.shape, dtype=bool)}
-        index_dict = {"Waveform": np.array([])}
+        sni_dict = {"Waveform": {"command": np.zeros(shotnum.shape, dtype=bool)}}
+        index_dict = {"Waveform": {"command": np.array([])}}
         self.assertRaises(
             ValueError, do_shotnum_intersection, shotnum, sni_dict, index_dict
         )
 
         # test a working case
         shotnum = np.arange(1, 21, 1)
-        sni_dict = {"Waveform": np.zeros(shotnum.shape, dtype=bool)}
-        index_dict = {"Waveform": np.array([5, 6, 7])}
-        sni_dict["Waveform"][[5, 6, 7]] = True
+        sni_dict = {"Waveform": {"command": np.zeros(shotnum.shape, dtype=bool)}}
+        index_dict = {"Waveform": {"command": np.array([5, 6, 7])}}
+        sni_dict["Waveform"]["command"][[5, 6, 7]] = True
         shotnum, sni_dict, index_dict = do_shotnum_intersection(
             shotnum, sni_dict, index_dict
         )
         self.assertTrue(np.array_equal(shotnum, [6, 7, 8]))
-        self.assertTrue(np.array_equal(sni_dict["Waveform"], [True] * 3))
-        self.assertTrue(np.array_equal(index_dict["Waveform"], [5, 6, 7]))
+        self.assertTrue(np.array_equal(sni_dict["Waveform"]["command"], [True] * 3))
+        self.assertTrue(np.array_equal(index_dict["Waveform"]["command"], [5, 6, 7]))
 
     def test_two_controls(self):
         """Test intersection behavior with two control devices"""
         # test a case that results in a null result
         shotnum = np.arange(1, 21, 1)
         sni_dict = {
-            "Waveform": np.zeros(shotnum.shape, dtype=bool),
-            "6K Compumotor": np.zeros(shotnum.shape, dtype=bool),
+            "Waveform": {"command": np.zeros(shotnum.shape, dtype=bool)},
+            "6K Compumotor": {0: np.zeros(shotnum.shape, dtype=bool)},
         }
-        index_dict = {"Waveform": np.array([]), "6K Compumotor": np.array([5, 6, 7])}
-        sni_dict["6K Compumotor"][[6, 7, 8]] = True
+        index_dict = {
+            "Waveform": {"command": np.array([])},
+            "6K Compumotor": {0: np.array([5, 6, 7])},
+        }
+        sni_dict["6K Compumotor"][0][[6, 7, 8]] = True
         self.assertRaises(
             ValueError, do_shotnum_intersection, shotnum, sni_dict, index_dict
         )
@@ -709,19 +706,23 @@ class TestDoShotnumIntersection(ut.TestCase):
         shotnum = np.arange(1, 21, 1)
         shotnum_dict = {"Waveform": shotnum, "6K Compumotor": shotnum}
         sni_dict = {
-            "Waveform": np.zeros(shotnum.shape, dtype=bool),
-            "6K Compumotor": np.zeros(shotnum.shape, dtype=bool),
+            "Waveform": {"command": np.zeros(shotnum.shape, dtype=bool)},
+            "6K Compumotor": {0: np.zeros(shotnum.shape, dtype=bool)},
         }
-        index_dict = {"Waveform": np.array([5, 6]), "6K Compumotor": np.array([5, 6, 7])}
-        sni_dict["Waveform"][[5, 6]] = True
-        sni_dict["6K Compumotor"][[5, 6, 7]] = True
+        index_dict = {
+            "Waveform": {"command": np.array([5, 6])},
+            "6K Compumotor": {0: np.array([5, 6, 7])},
+        }
+        sni_dict["Waveform"]["command"][[5, 6]] = True
+        sni_dict["6K Compumotor"][0][[5, 6, 7]] = True
         shotnum, sni_dict, index_dict = do_shotnum_intersection(
             shotnum, sni_dict, index_dict
         )
         self.assertTrue(np.array_equal(shotnum, [6, 7]))
         for key in shotnum_dict:
-            self.assertTrue(np.array_equal(sni_dict[key], [True] * 2))
-            self.assertTrue(np.array_equal(index_dict[key], [5, 6]))
+            for state_key in sni_dict[key]:
+                self.assertTrue(np.array_equal(sni_dict[key][state_key], [True] * 2))
+                self.assertTrue(np.array_equal(index_dict[key][state_key], [5, 6]))
 
 
 if __name__ == "__main__":

--- a/bapsflib/_hdf/utils/tests/test_helpers.py
+++ b/bapsflib/_hdf/utils/tests/test_helpers.py
@@ -192,19 +192,22 @@ class TestBuildShotnumDsetRelation(TestBase):
         cdset = self.cgroup["Run time list"]
         shotnumkey = "Shot number"
         configkey = "Configuration name"
-        for og_shotnum in shotnum_list:
+        for ii, og_shotnum in enumerate(shotnum_list):
             sn_arr = np.array(og_shotnum, dtype=np.uint32)
-            for cconfn in self.map.configs:
+            for jj, config_name in enumerate(self.map.configs):
+                config_column = configkey if (ii * jj) % 2 else None
+
                 index, sni = build_shotnum_dset_relation(
                     shotnum=sn_arr,
                     dset=cdset,
                     shotnumkey=shotnumkey,
                     n_configs=len(self.map.configs),
-                    config_id=cconfn,
+                    config_id=config_name,
+                    config_column=config_column,
                 )
 
                 self.assertSNSuite(
-                    sn_arr, index, sni, cdset, shotnumkey, configkey, cconfn
+                    sn_arr, index, sni, cdset, shotnumkey, configkey, config_name
                 )
 
     def assertSNSuite(self, shotnum, index, sni, cdset, shotnumkey, configkey, cconfn):

--- a/bapsflib/_hdf/utils/tests/test_helpers.py
+++ b/bapsflib/_hdf/utils/tests/test_helpers.py
@@ -21,7 +21,7 @@ from bapsflib._hdf.utils.file import File
 from bapsflib._hdf.utils.helpers import (
     build_shotnum_dset_relation,
     condition_controls,
-    condition_shotnum,
+    _condition_shotnum,
     do_shotnum_intersection,
 )
 from bapsflib._hdf.utils.tests import TestBase
@@ -536,12 +536,12 @@ class TestConditionShotnum(TestBase):
         sn = [-20, 0]
         for shotnum in sn:
             with self.assertRaises(ValueError):
-                _sn = condition_shotnum(shotnum, {}, {})
+                _sn = _condition_shotnum(shotnum, {}, {})
 
         # shotnum > 0 (valid)
         sn = [1, 100]
         for shotnum in sn:
-            _sn = condition_shotnum(shotnum, {}, {})
+            _sn = _condition_shotnum(shotnum, {}, {})
 
             self.assertIsInstance(_sn, np.ndarray)
             self.assertEqual(_sn.shape, (1,))
@@ -556,7 +556,7 @@ class TestConditionShotnum(TestBase):
         ]
         for shotnum in sn:
             with self.assertRaises(ValueError):
-                _sn = condition_shotnum(shotnum, {}, {})
+                _sn = _condition_shotnum(shotnum, {}, {})
 
         # all shotnum values are <= 0
         sn = [
@@ -565,7 +565,7 @@ class TestConditionShotnum(TestBase):
         ]
         for shotnum in sn:
             with self.assertRaises(ValueError):
-                _sn = condition_shotnum(shotnum, {}, {})
+                _sn = _condition_shotnum(shotnum, {}, {})
 
         # valid shotnum lists
         sn = [
@@ -574,7 +574,7 @@ class TestConditionShotnum(TestBase):
             ([1, 2, 4], np.array([1, 2, 4], dtype=np.uint32)),
         ]
         for shotnum, ex_sn in sn:
-            _sn = condition_shotnum(shotnum, {}, {})
+            _sn = _condition_shotnum(shotnum, {}, {})
 
             self.assertIsInstance(_sn, np.ndarray)
             self.assertTrue(np.array_equal(_sn, ex_sn))
@@ -600,7 +600,7 @@ class TestConditionShotnum(TestBase):
 
         # invalid shotnum slices (creates NULL arrays)
         with self.assertRaises(ValueError):
-            _sn = condition_shotnum(slice(-1, -4, 1), dset_dict, shotnumkey_dict)
+            _sn = _condition_shotnum(slice(-1, -4, 1), dset_dict, shotnumkey_dict)
 
         # valid shotnum slices
         sn = [
@@ -611,7 +611,7 @@ class TestConditionShotnum(TestBase):
             (slice(-2, -1), np.array([6], dtype=np.uint32)),
         ]
         for shotnum, ex_sn in sn:
-            _sn = condition_shotnum(shotnum, dset_dict, shotnumkey_dict)
+            _sn = _condition_shotnum(shotnum, dset_dict, shotnumkey_dict)
 
             self.assertIsInstance(_sn, np.ndarray)
             self.assertTrue(np.array_equal(_sn, ex_sn))
@@ -636,7 +636,7 @@ class TestConditionShotnum(TestBase):
         ]
         for shotnum in sn:
             with self.assertRaises(ValueError):
-                _sn = condition_shotnum(shotnum, {}, {})
+                _sn = _condition_shotnum(shotnum, {}, {})
 
         # shotnum valid
         sn = [
@@ -645,7 +645,7 @@ class TestConditionShotnum(TestBase):
             (np.array([20, 30], np.int32), np.array([20, 30], np.uint32)),
         ]
         for shotnum, ex_sn in sn:
-            _sn = condition_shotnum(shotnum, {}, {})
+            _sn = _condition_shotnum(shotnum, {}, {})
 
             self.assertIsInstance(_sn, np.ndarray)
             self.assertTrue(np.array_equal(_sn, ex_sn))
@@ -655,7 +655,7 @@ class TestConditionShotnum(TestBase):
         sn = [1.5, None, True, {}]
         for shotnum in sn:
             with self.assertRaises(ValueError):
-                _sn = condition_shotnum(shotnum, {}, {})
+                _sn = _condition_shotnum(shotnum, {}, {})
 
 
 class TestDoShotnumIntersection(ut.TestCase):

--- a/changelog/156.trivial.1.rst
+++ b/changelog/156.trivial.1.rst
@@ -1,0 +1,6 @@
+Signature of `~bapsflib._hdf.utils.helpers.build_shotnum_dset_relation` and
+`~bapsflib._hdf.utils.helpers.build_sndr_for_complex_dset` are updated to
+accept arguments ``shotnum``, ``dset``, ``shotnumkey``, ``n_configs``,
+``config_id``, and (optional) ``config_column``.  This allows for mapped
+``config['state values']`` entries to utilize separate datasets and
+custom configuration columns.

--- a/changelog/156.trivial.2.rst
+++ b/changelog/156.trivial.2.rst
@@ -1,0 +1,4 @@
+Signature of `~bapsflib._hdf.utils.helpers.condition_shotnum` is updated
+to accept arguments ``shotnum``, ``dset_list``, and ``shotnumkey_list``.
+This allows for mapped ``config['state values']`` entries to utilize
+separate datasets.

--- a/changelog/156.trivial.3.rst
+++ b/changelog/156.trivial.3.rst
@@ -1,0 +1,4 @@
+Updated `~bapsflib._hdf.utils.helpers.do_shotnum_intersection` so
+shot numbers are retrieved from the dataset associated with each
+mapped ``config['state values']``, and not the generic
+``config['dset paths']``.


### PR DESCRIPTION
This PR overhauls functionality in `bapsflib._hdf.utils.helpers.py` to make it more flexible to the various ways control devices can save their data.

- `build_shotnum_dset_relation()`
  - signature is changed so arguments are now `shotnum`, `dset`, `shotnumkey`, `n_configs`, `config_id`, and `config_column`
  - new signature allows for specifying the dataset `dset` column (`config_column`) for with the `config_id` will be searched for
- `build_sndr_for_simple_dset()`
  - only docstrings are updated
- `build_sndr_for_complex_dset()`
  - signature is to match that of `build_shotnum_dset_relation()`
- `condition_controls()`
  - only docstrings are updated
- `condition_shotnum()`
  - signature is changed to accept arguments `shotnum`, `dest_list`, and `shotnumkey_list`
  - `dset_list` and `shotnumkey_list` are one-to-one lists where `dset_list` contains the HDF5 datasets to be searched and `shotnumkey_list` contains the dataset field that contains the shot number values
- `do_shotnum_intersection()`
  - the intersection routines are update so the shot number is retrieved from the dataset associated with each `state values` entry.

Other changes...

- Many variables are renamed to a more explicit (and readable) version.
- Docstrings are reviewed for clarity, readability, and consistency.
- `HDFReadControls` and `HDFReadData` are update to utilize the updated signatures of the `helpers` functionality.
- `HDFReadControls` is updated knowing the fact that different `state values` entries can be associated with different datasets
- Add test `TestHDFReadControl.test_shotnum_dset_path_in_state_values()`
- Updated tests for all `helpers` functionality.