### PR TITLE
Add method `File.get_digitizer_specs()`

### DIFF
--- a/bapsflib/_hdf/utils/file.py
+++ b/bapsflib/_hdf/utils/file.py
@@ -37,7 +37,7 @@ class File(h5py.File):
         digitizer_path="/",
         msi_path="/",
         silent=False,
-        **kwargs
+        **kwargs,
     ):
         """
         Parameters
@@ -274,7 +274,7 @@ class File(h5py.File):
         shotnum=slice(None),
         intersection_set=True,
         silent=False,
-        **kwargs
+        **kwargs,
     ):
         """
         Reads data from control device datasets.  See
@@ -361,7 +361,7 @@ class File(h5py.File):
                 controls,
                 shotnum=shotnum,
                 intersection_set=intersection_set,
-                **kwargs
+                **kwargs,
             )
 
         return data
@@ -379,7 +379,7 @@ class File(h5py.File):
         add_controls=None,
         intersection_set=True,
         silent=False,
-        **kwargs
+        **kwargs,
     ):
         """
         Reads data from digitizer datasets and attaches control device
@@ -503,7 +503,7 @@ class File(h5py.File):
                 keep_bits=keep_bits,
                 add_controls=add_controls,
                 intersection_set=intersection_set,
-                **kwargs
+                **kwargs,
             )
 
         return data

--- a/bapsflib/_hdf/utils/file.py
+++ b/bapsflib/_hdf/utils/file.py
@@ -265,7 +265,6 @@ class File(h5py.File):
                 adc=adc,
                 config_name=config_name,
             )  # type: Dict[str, Any]
-            _info.update({"board": board, "channel": channel})
         return _info
 
     def read_controls(

--- a/bapsflib/_hdf/utils/file.py
+++ b/bapsflib/_hdf/utils/file.py
@@ -15,7 +15,7 @@ import h5py
 import os
 import warnings
 
-from typing import Any, Dict, Literal, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from bapsflib._hdf.maps import HDFMapControls, HDFMapDigitizers, HDFMapMSI, HDFMapper
 from bapsflib.utils.warnings import BaPSFWarning, HDFMappingWarning

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -140,8 +140,7 @@ class TestFile(TestBase):
         self.assertIsInstance(_bf.overview, HDFOverview)
 
     @with_bf
-    def test_file(self, _bf: File):
-        # calling `read_controls`
+    def test_read_controls(self, _bf: File):
         with mock.patch(
             f"{HDFReadControls.__module__}.{HDFReadControls.__qualname__}",
             return_value="read control",
@@ -155,7 +154,8 @@ class TestFile(TestBase):
             self.assertEqual(cdata, "read control")
             mock_rc.assert_called_once_with(_bf, ["control"], **extras)
 
-        # calling `read_data`
+    @with_bf
+    def test_read_data(self, _bf: File):
         with mock.patch(
             f"{HDFReadData.__module__}.{HDFReadData.__qualname__}",
             return_value="read data",
@@ -175,15 +175,19 @@ class TestFile(TestBase):
             self.assertEqual(data, "read data")
             mock_rd.assert_called_once_with(_bf, 1, 2, **extras)
 
-        # calling `read_msi`
+    @with_bf
+    def test_read_msi(self, _bf: File):
         with mock.patch(
-            f"{HDFReadMSI.__module__}.{HDFReadMSI.__qualname__}", return_value="read msi"
+                f"{HDFReadMSI.__module__}.{HDFReadMSI.__qualname__}",
+                return_value="read msi"
         ) as mock_rm:
             mdata = _bf.read_msi("Discharge", silent=False)
             self.assertTrue(mock_rm.called)
             self.assertEqual(mdata, "read msi")
             mock_rm.assert_called_once_with(_bf, "Discharge")
 
+    @with_bf
+    def test_file(self, _bf: File):
         # __init__ calling                                          ----
         # methods `_build_info` and `_map_file` should be called in
         # __init__

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -51,12 +51,17 @@ class TestFile(TestBase):
             # 'info' attributes
             "_build_info",
             "info",
-            # mapping attributes
+            # mapping attributes/methods
             "_map_file",
             "file_map",
             "controls",
             "digitizers",
             "msi",
+            # read data attributes/methods
+            "read_data",
+            "read_controls",
+            "read_msi",
+            #
         ]
         for attr_name in _conditions:
             with self.subTest(attr_name=attr_name):
@@ -111,11 +116,6 @@ class TestFile(TestBase):
         self.assertTrue(hasattr(_bf, "overview"))
         self.assertIsInstance(type(_bf).overview, property)
         self.assertIsInstance(_bf.overview, HDFOverview)
-
-        # read attributes                                           ----
-        self.assertTrue(hasattr(_bf, "read_controls"))
-        self.assertTrue(hasattr(_bf, "read_data"))
-        self.assertTrue(hasattr(_bf, "read_msi"))
 
         # calling `read_controls`
         with mock.patch(

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -13,7 +13,6 @@
 #
 import h5py
 import os
-import unittest as ut
 
 from unittest import mock
 

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -42,6 +42,27 @@ class TestFile(TestBase):
         self.assertIsInstance(_bf, h5py.File)
 
     @with_bf
+    def test_attribute_existence(self, _bf: File):
+        _conditions = [  # attribute name
+            # path attributes
+            "CONTROL_PATH",
+            "DIGITIZER_PATH",
+            "MSI_PATH",
+            # 'info' attributes
+            "_build_info",
+            "info",
+            # mapping attributes
+            "_map_file",
+            "file_map",
+            "controls",
+            "digitizers",
+            "msi",
+        ]
+        for attr_name in _conditions:
+            with self.subTest(attr_name=attr_name):
+                self.assertTrue(hasattr(_bf, attr_name))
+
+    @with_bf
     def test_file(self, _bf: File):
 
         # path attributes

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -63,12 +63,19 @@ class TestFile(TestBase):
                 self.assertTrue(hasattr(_bf, attr_name))
 
     @with_bf
-    def test_file(self, _bf: File):
+    def test_path_attribute_values(self, _bf: File):
+        _conditions = [
+            # (attr_name, expected)
+            ("CONTROL_PATH", "Raw data + config"),
+            ("DIGITIZER_PATH", "Raw data + config"),
+            ("MSI_PATH", "MSI"),
+        ]
+        for attr_name, expected in _conditions:
+            with self.subTest(attr_name=attr_name, expected=expected):
+                self.assertEqual(getattr(_bf, attr_name), expected)
 
-        # path attributes
-        self.assertEqual(_bf.CONTROL_PATH, "Raw data + config")
-        self.assertEqual(_bf.DIGITIZER_PATH, "Raw data + config")
-        self.assertEqual(_bf.MSI_PATH, "MSI")
+    @with_bf
+    def test_file(self, _bf: File):
 
         # `info` attributes`                                        ----
         self.assertIsInstance(_bf.info, dict)

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -124,7 +124,9 @@ class TestFile(TestBase):
     def test_mapping_properties(self, _bf: File):
         _conditions = [
             # property name
-            "controls", "digitizers", "msi",
+            "controls",
+            "digitizers",
+            "msi",
         ]
         for attr_name in _conditions:
             with self.subTest(attr_name=attr_name):
@@ -173,8 +175,7 @@ class TestFile(TestBase):
     @with_bf
     def test_read_msi(self, _bf: File):
         with mock.patch(
-                f"{HDFReadMSI.__module__}.{HDFReadMSI.__qualname__}",
-                return_value="read msi"
+            f"{HDFReadMSI.__module__}.{HDFReadMSI.__qualname__}", return_value="read msi"
         ) as mock_rm:
             mdata = _bf.read_msi("Discharge", silent=False)
             self.assertTrue(mock_rm.called)
@@ -261,7 +262,9 @@ class TestFile(TestBase):
             f"{HDFMapDigiTemplate.__module__}.{HDFMapDigiTemplate.__qualname__}.get_adc_info",
             return_value="mapped",
         ) as mock_map:
-            _bf.get_digitizer_specs(1, 1, digitizer="SIS crate", adc="SIS 3302", silent=True)
+            _bf.get_digitizer_specs(
+                1, 1, digitizer="SIS crate", adc="SIS 3302", silent=True
+            )
             mock_map.assert_called_once()
 
         _bf.close()

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -267,6 +267,22 @@ class TestFile(TestBase):
         _bf.close()
         self.f.reset()
 
+    def test_get_digitizer_specs(self):
+        self.f.reset()
+        self.f.add_module("SIS crate")
+        _bf = File(
+            self.f.filename,
+            control_path="Raw data + config",
+            digitizer_path="Raw data + config",
+            msi_path="MSI",
+        )
+
+        expected = _bf.digitizers["SIS crate"].get_adc_info(
+            1, 1, adc="SIS 3302", config_name="config01"
+        )
+        specs = _bf.get_digitizer_specs(1, 1, adc="SIS 3302", silent=True)
+        self.assertDictEqual(expected, specs)
+
     def test_get_digitizer_specs_raises(self):
         self.f.reset()
         self.f.add_module("SIS crate")

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -92,29 +92,37 @@ class TestFile(TestBase):
             self.assertEqual(_bf._file_map, "mapped")
 
     @with_bf
+    def test_attributes_as_property(self, _bf: File):
+        _conditions = [  # attribute name
+            "info",
+            "file_map",
+            "controls",
+            "digitizers",
+            "msi",
+            "overview",
+        ]
+        for attr_name in _conditions:
+            with self.subTest(attr_name=attr_name):
+                self.assertIsInstance(getattr(type(_bf), attr_name), property)
+
+    @with_bf
     def test_file(self, _bf: File):
 
         # `info` attributes`                                        ----
         self.assertIsInstance(_bf.info, dict)
-        self.assertIsInstance(type(_bf).info, property)
         self.assertEqual(_bf.info["file"], os.path.basename(_bf.filename))
         self.assertEqual(_bf.info["absolute file path"], os.path.abspath(_bf.filename))
 
         # `file_map`
         self.assertIsInstance(_bf.file_map, HDFMapper)
-        self.assertIsInstance(type(_bf).file_map, property)
 
         # individual mappings
-        self.assertIsInstance(type(_bf).controls, property)
         self.assertIs(_bf.controls, _bf.file_map.controls)
-        self.assertIsInstance(type(_bf).digitizers, property)
         self.assertIs(_bf.digitizers, _bf.file_map.digitizers)
-        self.assertIsInstance(type(_bf).msi, property)
         self.assertIs(_bf.msi, _bf.file_map.msi)
 
         # `overview` attribute                                      ----
         self.assertTrue(hasattr(_bf, "overview"))
-        self.assertIsInstance(type(_bf).overview, property)
         self.assertIsInstance(_bf.overview, HDFOverview)
 
         # calling `read_controls`

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -122,15 +122,21 @@ class TestFile(TestBase):
                     _assert(_bf.info[key], expected)
 
     @with_bf
-    def test_file(self, _bf: File):
-        # `file_map`
+    def test_file_map(self, _bf: File):
         self.assertIsInstance(_bf.file_map, HDFMapper)
 
-        # individual mappings
-        self.assertIs(_bf.controls, _bf.file_map.controls)
-        self.assertIs(_bf.digitizers, _bf.file_map.digitizers)
-        self.assertIs(_bf.msi, _bf.file_map.msi)
+    @with_bf
+    def test_mapping_properties(self, _bf: File):
+        _conditions = [
+            # property name
+            "controls", "digitizers", "msi",
+        ]
+        for attr_name in _conditions:
+            with self.subTest(attr_name=attr_name):
+                self.assertIs(getattr(_bf, attr_name), getattr(_bf.file_map, attr_name))
 
+    @with_bf
+    def test_file(self, _bf: File):
         # `overview` attribute                                      ----
         self.assertIsInstance(_bf.overview, HDFOverview)
 

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -37,32 +37,23 @@ class TestFile(TestBase):
         super().tearDown()
 
     @with_bf
-    def test_file(self, _bf: File):
-        # must by h5py.File instance
+    def test_file_subclass(self, _bf: File):
+        # must be h5py.File instance
         self.assertIsInstance(_bf, h5py.File)
 
+    @with_bf
+    def test_file(self, _bf: File):
+
         # path attributes
-        self.assertTrue(hasattr(_bf, "CONTROL_PATH"))
-        self.assertTrue(hasattr(_bf, "DIGITIZER_PATH"))
-        self.assertTrue(hasattr(_bf, "MSI_PATH"))
         self.assertEqual(_bf.CONTROL_PATH, "Raw data + config")
         self.assertEqual(_bf.DIGITIZER_PATH, "Raw data + config")
         self.assertEqual(_bf.MSI_PATH, "MSI")
 
         # `info` attributes`                                        ----
-        self.assertTrue(hasattr(_bf, "_build_info"))
-        self.assertTrue(hasattr(_bf, "info"))
         self.assertIsInstance(_bf.info, dict)
         self.assertIsInstance(type(_bf).info, property)
         self.assertEqual(_bf.info["file"], os.path.basename(_bf.filename))
         self.assertEqual(_bf.info["absolute file path"], os.path.abspath(_bf.filename))
-
-        # mapping attributes                                        ----
-        self.assertTrue(hasattr(_bf, "_map_file"))
-        self.assertTrue(hasattr(_bf, "file_map"))
-        self.assertTrue(hasattr(_bf, "controls"))
-        self.assertTrue(hasattr(_bf, "digitizers"))
-        self.assertTrue(hasattr(_bf, "msi"))
 
         # `_map_file` should call HDFMapper
         with mock.patch(

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -136,10 +136,11 @@ class TestFile(TestBase):
                 self.assertIs(getattr(_bf, attr_name), getattr(_bf.file_map, attr_name))
 
     @with_bf
-    def test_file(self, _bf: File):
-        # `overview` attribute                                      ----
+    def test_overview(self, _bf: File):
         self.assertIsInstance(_bf.overview, HDFOverview)
 
+    @with_bf
+    def test_file(self, _bf: File):
         # calling `read_controls`
         with mock.patch(
             f"{HDFReadControls.__module__}.{HDFReadControls.__qualname__}",

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -214,10 +214,8 @@ class TestFile(TestBase):
                     _bf2.close()
 
     @with_bf
-    def test_file(self, _bf: File):
-        # __init__ calling                                          ----
+    def test_file_init_sequence(self, _bf: File):
         # methods `_build_info` and `_map_file` should be called in
-        # __init__
         with mock.patch.object(
             File, "_build_info", side_effect=_bf._build_info
         ) as mock_bi, mock.patch.object(
@@ -232,7 +230,3 @@ class TestFile(TestBase):
             self.assertTrue(mock_mf.called)
             self.assertTrue(mock_bi.called)
             _bf2.close()
-
-
-if __name__ == "__main__":
-    ut.main()

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -30,12 +30,6 @@ from bapsflib.utils.decorators import with_bf
 class TestFile(TestBase):
     """Test case for :class:`~bapsflib._hdf.utils.file.File`."""
 
-    def setUp(self):
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-
     @with_bf
     def test_file_subclass(self, _bf: File):
         # must be h5py.File instance

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -196,6 +196,24 @@ class TestFile(TestBase):
                 _bf2.close()
 
     @with_bf
+    def test_file_correct_open_mode(self, _bf: File):
+        with mock.patch("h5py.File.__init__", wraps=h5py.File.__init__) as mock_file:
+            for mode in ("r", "r+"):
+                with self.subTest(mode=mode):
+                    _bf2 = File(
+                        self.f.filename,
+                        mode=mode,
+                        control_path="Raw data + config",
+                        digitizer_path="Raw data + config",
+                        msi_path="MSI",
+                        silent=True,
+                    )
+                    self.assertTrue(mock_file.called)
+                    mock_file.assert_called_once_with(_bf2, self.f.filename, mode=mode)
+                    mock_file.reset_mock()
+                    _bf2.close()
+
+    @with_bf
     def test_file(self, _bf: File):
         # __init__ calling                                          ----
         # methods `_build_info` and `_map_file` should be called in
@@ -214,22 +232,6 @@ class TestFile(TestBase):
             self.assertTrue(mock_mf.called)
             self.assertTrue(mock_bi.called)
             _bf2.close()
-
-        # `mode` calling
-        with mock.patch("h5py.File.__init__", wraps=h5py.File.__init__) as mock_file:
-            for mode in ("r", "r+"):
-                _bf2 = File(
-                    self.f.filename,
-                    mode=mode,
-                    control_path="Raw data + config",
-                    digitizer_path="Raw data + config",
-                    msi_path="MSI",
-                    silent=True,
-                )
-                self.assertTrue(mock_file.called)
-                mock_file.assert_called_once_with(_bf2, self.f.filename, mode=mode)
-                mock_file.reset_mock()
-                _bf2.close()
 
 
 if __name__ == "__main__":

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -61,7 +61,8 @@ class TestFile(TestBase):
             "read_data",
             "read_controls",
             "read_msi",
-            #
+            # other attributes/methods
+            "overview",
         ]
         for attr_name in _conditions:
             with self.subTest(attr_name=attr_name):
@@ -122,7 +123,6 @@ class TestFile(TestBase):
         self.assertIs(_bf.msi, _bf.file_map.msi)
 
         # `overview` attribute                                      ----
-        self.assertTrue(hasattr(_bf, "overview"))
         self.assertIsInstance(_bf.overview, HDFOverview)
 
         # calling `read_controls`

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -80,6 +80,18 @@ class TestFile(TestBase):
                 self.assertEqual(getattr(_bf, attr_name), expected)
 
     @with_bf
+    def test_map_file_call(self, _bf: File):
+        # `_map_file` should call HDFMapper
+        with mock.patch(
+            f"{File.__module__}.{HDFMapper.__qualname__}", return_value="mapped"
+        ) as mock_map:
+
+            _bf._map_file()
+
+            self.assertTrue(mock_map.called)
+            self.assertEqual(_bf._file_map, "mapped")
+
+    @with_bf
     def test_file(self, _bf: File):
 
         # `info` attributes`                                        ----
@@ -87,18 +99,6 @@ class TestFile(TestBase):
         self.assertIsInstance(type(_bf).info, property)
         self.assertEqual(_bf.info["file"], os.path.basename(_bf.filename))
         self.assertEqual(_bf.info["absolute file path"], os.path.abspath(_bf.filename))
-
-        # `_map_file` should call HDFMapper
-        with mock.patch(
-            f"{File.__module__}.{HDFMapper.__qualname__}", return_value="mapped"
-        ) as mock_map:
-
-            _bf._map_file()
-            self.assertTrue(mock_map.called)
-            self.assertEqual(_bf._file_map, "mapped")
-
-        # restore map
-        _bf._map_file()
 
         # `file_map`
         self.assertIsInstance(_bf.file_map, HDFMapper)

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -107,13 +107,22 @@ class TestFile(TestBase):
                 self.assertIsInstance(getattr(type(_bf), attr_name), property)
 
     @with_bf
+    def test_info_property(self, _bf: File):
+        _conditions = [
+            # (_assert, key, expected)
+            (self.assertIsInstance, None, dict),
+            (self.assertEqual, "file", os.path.basename(_bf.filename)),
+            (self.assertEqual, "absolute file path", os.path.abspath(_bf.filename)),
+        ]
+        for _assert, key, expected in _conditions:
+            with self.subTest(_assert=_assert.__name__, key=key, expected=expected):
+                if key is None:
+                    _assert(_bf.info, expected)
+                else:
+                    _assert(_bf.info[key], expected)
+
+    @with_bf
     def test_file(self, _bf: File):
-
-        # `info` attributes`                                        ----
-        self.assertIsInstance(_bf.info, dict)
-        self.assertEqual(_bf.info["file"], os.path.basename(_bf.filename))
-        self.assertEqual(_bf.info["absolute file path"], os.path.abspath(_bf.filename))
-
         # `file_map`
         self.assertIsInstance(_bf.file_map, HDFMapper)
 

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -187,6 +187,15 @@ class TestFile(TestBase):
             mock_rm.assert_called_once_with(_bf, "Discharge")
 
     @with_bf
+    def test_file_wrong_open_mode(self, _bf: File):
+        # raise ValueError if mode not in ('r', 'r+')
+        modes = ["w", "w-", "x", "a"]
+        for mode in modes:
+            with self.subTest(mode=mode), self.assertRaises(ValueError):
+                _bf2 = File(self.f.filename, mode=mode)
+                _bf2.close()
+
+    @with_bf
     def test_file(self, _bf: File):
         # __init__ calling                                          ----
         # methods `_build_info` and `_map_file` should be called in
@@ -221,11 +230,6 @@ class TestFile(TestBase):
                 mock_file.assert_called_once_with(_bf2, self.f.filename, mode=mode)
                 mock_file.reset_mock()
                 _bf2.close()
-
-        # raise ValueError if mode not in ('r', 'r+')
-        with self.assertRaises(ValueError):
-            _bf2 = File(self.f.filename, mode="w")
-            _bf2.close()
 
 
 if __name__ == "__main__":

--- a/bapsflib/_hdf/utils/tests/test_file.py
+++ b/bapsflib/_hdf/utils/tests/test_file.py
@@ -17,6 +17,7 @@ import os
 from unittest import mock
 
 from bapsflib._hdf import HDFMapper
+from bapsflib._hdf.maps.digitizers.templates import HDFMapDigiTemplate
 from bapsflib._hdf.utils.file import File
 from bapsflib._hdf.utils.hdfoverview import HDFOverview
 from bapsflib._hdf.utils.hdfreadcontrols import HDFReadControls
@@ -224,6 +225,48 @@ class TestFile(TestBase):
             self.assertTrue(mock_mf.called)
             self.assertTrue(mock_bi.called)
             _bf2.close()
+
+    def test_get_digitizer_specs_one_digi(self):
+        self.f.reset()
+        self.f.add_module("SIS crate")
+        _bf = File(
+            self.f.filename,
+            control_path="Raw data + config",
+            digitizer_path="Raw data + config",
+            msi_path="MSI",
+        )
+
+        with mock.patch(
+            f"{HDFMapDigiTemplate.__module__}.{HDFMapDigiTemplate.__qualname__}.get_adc_info",
+            return_value="mapped",
+        ) as mock_map:
+            _bf.get_digitizer_specs(1, 1, digitizer=None, adc="SIS 3302", silent=True)
+            mock_map.assert_called_once()
+
+        _bf.close()
+        self.f.reset()
+
+    def test_get_digitizer_specs_two_digi(self):
+        self.f.reset()
+        self.f.add_module("SIS 3301")
+        self.f.add_module("SIS crate")
+        _bf = File(
+            self.f.filename,
+            control_path="Raw data + config",
+            digitizer_path="Raw data + config",
+            msi_path="MSI",
+        )
+
+        with mock.patch(
+            f"{HDFMapDigiTemplate.__module__}.{HDFMapDigiTemplate.__qualname__}.get_adc_info",
+            return_value="mapped",
+        ) as mock_map:
+            _bf.get_digitizer_specs(1, 1, digitizer="SIS crate", adc="SIS 3302", silent=True)
+            mock_map.assert_called_once()
+
+        _bf.close()
+        self.f.reset()
+
     def test_get_digitizer_specs_raises(self):
         self.f.reset()
         self.f.add_module("SIS crate")

--- a/changelog/158.feature.rst
+++ b/changelog/158.feature.rst
@@ -1,0 +1,4 @@
+Added method `~bapsflib._hdf.utils.file.File.get_digitizer_specs` to
+`~bapsflib._hdf.utils.file.File`.  This allows users to gather
+digitizer information without first reading data or navigating through
+the mapping objects.


### PR DESCRIPTION
Add method `get_digitizer_specs()` to the `File` class to more easily retrieve specs of the deployed digitizer.  This is a convenience method so users do NOT have to read data or navigate through the digitizer mapping objects to retrieve the desired digitizer specifications.