### PR TITLE
Refactor  `HDFMapControlTemplate.get_config_id` -> `get_config_column_value`

### DIFF
--- a/bapsflib/_hdf/maps/controls/bmotion.py
+++ b/bapsflib/_hdf/maps/controls/bmotion.py
@@ -356,11 +356,9 @@ class HDFMapControlBMotion(HDFMapControlTemplate):
             )
         return name
 
-    def get_config_id(self, config_name: str) -> str:
-        """
-        Get the configuration "motion group" id for the specified
-        ``config_name``.
-        """
+    def get_config_column_value(self, config_name: str) -> Union[str, None]:
+        # bmotion uses the motion_group_id column as the configuration column,
+        # so this method will return the motion group ID or None
         id_and_mg_name = self._split_config_name(config_name)
         return None if id_and_mg_name is None else id_and_mg_name[0]
 

--- a/bapsflib/_hdf/maps/controls/templates.py
+++ b/bapsflib/_hdf/maps/controls/templates.py
@@ -233,7 +233,9 @@ class HDFMapControlTemplate(HDFMapTemplate, ABC):
         """Name of Control device"""
         return self.group_name
 
-    def get_config_column_value(self, config_name: Union[str, int]) -> str:
+    def get_config_column_value(  # noqa: PLR6301
+        self, config_name: Union[str, int]
+    ) -> Union[str, None]:
         """
         For the given configuration name ``config_name`` get the
         associated configuration value that would be in the

--- a/bapsflib/_hdf/maps/controls/templates.py
+++ b/bapsflib/_hdf/maps/controls/templates.py
@@ -233,14 +233,15 @@ class HDFMapControlTemplate(HDFMapTemplate, ABC):
         """Name of Control device"""
         return self.group_name
 
-    def get_config_id(self, config_name: str) -> str:
+    def get_config_column_value(self, config_name: Union[str, int]) -> str:
         """
-        Get the configuration identifier for the given ``config_name``.
-        This identifier is the string value used in the HDF5 datasets.
+        For the given configuration name ``config_name`` get the
+        associated configuration value that would be in the
+        configuration column of the associated HDF5 datasets.
 
         Parameters
         ----------
-        config_name : `str`
+        config_name : `str` or  `int`
             The configuration name used in :attr:`configs`.
         """
         return config_name

--- a/bapsflib/_hdf/maps/controls/templates.py
+++ b/bapsflib/_hdf/maps/controls/templates.py
@@ -239,6 +239,13 @@ class HDFMapControlTemplate(HDFMapTemplate, ABC):
         associated configuration value that would be in the
         configuration column of the associated HDF5 datasets.
 
+        Typically, the column value is just ``config_name``, but
+        subclasses may override this to provide more sophisticated
+        behavior.  For example, if ``config_name`` is a mash-up of the
+        column value and some other specifier, then this method can be
+        used to do the proper `regex` to pull out the column value from
+        ``config_name``.
+
         Parameters
         ----------
         config_name : `str` or  `int`

--- a/bapsflib/_hdf/maps/controls/tests/test_bmotion.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_bmotion.py
@@ -350,7 +350,7 @@ class TestBMotion(ControlTestCase):
                 expected=expected,
             )
 
-    def test_get_config_id(self):
+    def test_get_config_column_value(self):
         _map = self.map
         _conditions = [
             # (_assert, args, expected)
@@ -364,7 +364,7 @@ class TestBMotion(ControlTestCase):
         for _assert, args, expected in _conditions:
             self.assert_runner(
                 _assert=_assert,
-                attr=_map.get_config_id,
+                attr=_map.get_config_column_value,
                 args=args,
                 kwargs={},
                 expected=expected,

--- a/bapsflib/_hdf/maps/controls/tests/test_templates.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_templates.py
@@ -94,7 +94,7 @@ class ControlTemplateTestCase:
             "_contype",
             "contype",
             "device_name",
-            "get_config_id",
+            "get_config_column_value",
             "has_command_list",
             "one_config_per_dset",
         }
@@ -125,9 +125,9 @@ class ControlTemplateTestCase:
         with self.assertRaises(TypeError):
             self._DummyMap(None)
 
-    def test_get_config_id(self):
+    def test_get_config_column_value(self):
         _map = self._DummyMap(self.control_group)
-        self.assertEqual(_map.get_config_id("config01"), "config01")
+        self.assertEqual(_map.get_config_column_value("config01"), "config01")
 
     def test_one_config_per_dset(self):
         # control_group is set up with 3 datasets

--- a/bapsflib/_hdf/utils/hdfreadcontrols.py
+++ b/bapsflib/_hdf/utils/hdfreadcontrols.py
@@ -302,7 +302,7 @@ class HDFReadControls(np.ndarray):
                     dset=hdf_file.get(entry["dset paths"][0]),
                     shotnumkey=control_config["shotnum"]["dset field"][0],
                     n_configs=n_configs,
-                    config_id=control_map.get_config_id(config_name),
+                    config_column_value=control_map.get_config_column_value(config_name),
                     config_column=config_column,
                 )
                 index_dict[control_name][key] = _index

--- a/bapsflib/_hdf/utils/helpers.py
+++ b/bapsflib/_hdf/utils/helpers.py
@@ -70,9 +70,8 @@ def build_shotnum_dset_relation(
         The number of unique configurations contained in ``dset``.
 
     config_column_value : `Any`
-        The configuration identification.  Typically, the name of the
-        configuration.  This is the value searched for in the data
-        contained in the ``config_column``.
+        The configuration value to searched for in ``config_column``.
+        This is typically the name of the device configuration.
 
     config_column : Optional[`str`]
         Name of the ``dset`` column containing control configurations.
@@ -266,9 +265,8 @@ def build_sndr_for_complex_dset(
         The number of unique configurations contained in ``dset``.
 
     config_column_value : `Any`
-        The configuration identification.  Typically, the name of the
-        configuration.  This is the value searched for in the data
-        contained in the ``config_column``.
+        The configuration value to searched for in ``config_column``.
+        This is typically the name of the device configuration.
 
     config_column : Optional[`str`]
         Name of the ``dset`` column containing control configurations.

--- a/bapsflib/_hdf/utils/helpers.py
+++ b/bapsflib/_hdf/utils/helpers.py
@@ -38,7 +38,7 @@ def build_shotnum_dset_relation(
     dset: h5py.Dataset,
     shotnumkey: str,
     n_configs: int,
-    config_id: Any,
+    config_column_value: Any,
     config_column: Optional[str] = None,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """
@@ -69,7 +69,7 @@ def build_shotnum_dset_relation(
     n_configs : int
         The number of unique configurations contained in ``dset``.
 
-    config_id : `Any`
+    config_column_value : `Any`
         The configuration identification.  Typically, the name of the
         configuration.  This is the value searched for in the data
         contained in the ``config_column``.
@@ -106,7 +106,7 @@ def build_shotnum_dset_relation(
             dset=dset,
             shotnumkey=shotnumkey,
             n_configs=n_configs,
-            config_id=config_id,
+            config_column_value=config_column_value,
             config_column=config_column,
         )
 
@@ -219,7 +219,7 @@ def build_sndr_for_complex_dset(
     dset: h5py.Dataset,
     shotnumkey: str,
     n_configs: int,
-    config_id: Any,
+    config_column_value: Any,
     config_column: Optional[str] = None,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """
@@ -265,7 +265,7 @@ def build_sndr_for_complex_dset(
     n_configs : `int`
         The number of unique configurations contained in ``dset``.
 
-    config_id : `Any`
+    config_column_value : `Any`
         The configuration identification.  Typically, the name of the
         configuration.  This is the value searched for in the data
         contained in the ``config_column``.
@@ -309,7 +309,7 @@ def build_sndr_for_complex_dset(
         #       name of the configuration.  When reading that into a
         #       numpy array the string becomes a byte string (i.e. b'').
         #       When comparing with np.where() the comparing string
-        #       needs to be encoded (i.e. config_id.encode()).
+        #       needs to be encoded (i.e. config_column_value.encode()).
         #
         only_sn = dset[0, shotnumkey]
         sni = np.where(shotnum == only_sn, True, False)
@@ -320,7 +320,7 @@ def build_sndr_for_complex_dset(
             index = np.empty(shape=0, dtype=np.uint32)
         else:
             config_name_arr = dset[0:n_configs, configkey]
-            index = np.where(config_name_arr == config_id.encode())[0]
+            index = np.where(config_name_arr == config_column_value.encode())[0]
 
             if index.size != 1:  # pragma: no cover
                 # something went wrong...no configurations are found
@@ -338,7 +338,7 @@ def build_sndr_for_complex_dset(
         # find sub-group index corresponding to the requested device
         # configuration
         config_name_arr = dset[0:n_configs, configkey]
-        config_where = np.where(config_name_arr == config_id.encode())[0]
+        config_where = np.where(config_name_arr == config_column_value.encode())[0]
         if config_where.size == 1:
             config_subindex = config_where[0]
         else:  # pragma: no cover

--- a/bapsflib/_hdf/utils/tests/test_helpers.py
+++ b/bapsflib/_hdf/utils/tests/test_helpers.py
@@ -126,7 +126,7 @@ class TestBuildShotnumDsetRelation(TestBase):
                 dset=cdset,
                 shotnumkey="Shot number",
                 n_configs=len(self.map.configs),
-                config_id="config01",
+                config_column_value="config01",
             )
 
     def assertInRangeSN(self):
@@ -158,7 +158,7 @@ class TestBuildShotnumDsetRelation(TestBase):
                     dset=cdset,
                     shotnumkey=shotnumkey,
                     n_configs=len(self.map.configs),
-                    config_id=cconfn,
+                    config_column_value=cconfn,
                 )
 
                 self.assertSNSuite(
@@ -202,7 +202,7 @@ class TestBuildShotnumDsetRelation(TestBase):
                     dset=cdset,
                     shotnumkey=shotnumkey,
                     n_configs=len(self.map.configs),
-                    config_id=config_name,
+                    config_column_value=config_name,
                     config_column=config_column,
                 )
 


### PR DESCRIPTION
Refactor `HDFMapControlTemplate.get_config_id` -> `get_config_column_value`.  This is a more explicit name for the functionality the method provides.  The method will generate the value contain in the value found in the HDF5 dataset that is associated with the given configuration name `config_name`.  This typically just returns an unaltered `config_name`, but sub-classes can override to provide more complex behavior.