### PR TITLE
Drop support/testing for python 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,13 +22,13 @@ jobs:
       matrix:
         include:
           # mark default
-          - python: '3.9'
+          - python: '3.10'
             os: ubuntu-latest
             do-coverage: false
             name-modifier: ''
 
           # mark case for coverage reporting
-          - python: '3.10'
+          - python: '3.14'
             os: ubuntu-latest
             do-coverage: true
             name-modifier: 'with Coverage'
@@ -70,14 +70,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: [ubuntu-latest, macos-latest, windows-latest]
 
         exclude:
           # these were done in base-tests
           - python: '3.10'
             os: ubuntu-latest
-          - python: '3.9'
+          - python: '3.14'
             os: ubuntu-latest
 
     steps:
@@ -110,11 +110,11 @@ jobs:
         include:
           - spec-name: h5py v3.0
             min-install: h5py==3.0
-            python: '3.9'
+            python: '3.10'
 
           - spec-name: h5py v3.0 numpy v1.20
             min-install: h5py==3.0 numpy==1.20
-            python: '3.9'
+            python: '3.10'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,40 +98,6 @@ jobs:
             python -m unittest discover
         shell: bash
 
-  test-mins:
-    # test min versions of key dependencies
-    needs: tests
-    name: Min Vers | py-${{ matrix.python }} | ${{ matrix.spec-name }}
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - spec-name: h5py v3.0
-            min-install: h5py==3.0
-            python: '3.10'
-
-          - spec-name: h5py v3.0 numpy v1.20
-            min-install: h5py==3.0 numpy==1.20
-            python: '3.10'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install 'bapsflib' dependencies
-        run: |
-          python -m pip install pip --upgrade
-          python -m pip install -r requirements/tests.txt ${{ matrix.min-install }}
-      - name: Run tests
-        run: python -m unittest discover
-
   import-bapsflib:
     name: Importing bapsflib
     needs: base-tests
@@ -159,7 +125,7 @@ jobs:
     name: Packaging
     runs-on: ubuntu-latest
     needs:
-      - test-mins
+      - tests
       - import-bapsflib
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![h5py](https://img.shields.io/badge/powered%20by-h5py-%235e9ffa.svg)](https://www.h5py.org/)
 
-The **bapsflib** package is developed on Python 3.9+ and is intended to 
+The **bapsflib** package is developed on Python 3.10+ and is intended to 
 be a toolkit for reading, manipulating, and analyzing data collected at 
 the Basic Plasma Science Facility 
 ([BaPSF](http://plasma.physics.ucla.edu/)) at UCLA. 

--- a/bapsflib/__init__.py
+++ b/bapsflib/__init__.py
@@ -18,8 +18,8 @@ __all__ = ["lapd"]
 
 import sys
 
-if sys.version_info < (3, 9):  # coverage: ignore
-    raise ImportError("bapsflib does not support Python < 3.9")
+if sys.version_info < (3, 10):  # coverage: ignore
+    raise ImportError("bapsflib does not support Python < 3.10")
 
 from importlib.metadata import PackageNotFoundError, version
 

--- a/bapsflib/_hdf/maps/controls/parsers.py
+++ b/bapsflib/_hdf/maps/controls/parsers.py
@@ -57,7 +57,7 @@ class CLParse(object):
         self._cl = command_list
 
     def apply_patterns(self, patterns: Union[str, Iterable[str]]):
-        """
+        r"""
         Applies the regular expressions defined in `patterns` to parse
         the command list.
 
@@ -80,14 +80,16 @@ class CLParse(object):
         --------
 
             >>> # define a command list
-            >>> cl = ['VOLT 20.0', 'VOLT 25.0', 'VOLT 30.0']
+            >>> cl = ["VOLT 20.0", "VOLT 25.0", "VOLT 30.0"]
             >>>
             >>> # define clparse object
             >>> clparse = CLParse(cl)
             >>>
             >>> # apply patterns
-            >>> patterns = (r'(?P<FREQ>(\bFREQ\s)'
-            >>>             + r'(?P<VAL>(\d+\.\d*|\.\d+|\d+\b)))')
+            >>> patterns = (
+            >>>     r"(?P<FREQ>(\bFREQ\s)"
+            >>>     r"(?P<VAL>(\d+\.\d*|\.\d+|\d+\b)))"
+            >>> )
             >>> results = clparse.apply_patterns(patterns)
             >>> results[0]
             True

--- a/bapsflib/_hdf/maps/digitizers/tests/fauxsis3301.py
+++ b/bapsflib/_hdf/maps/digitizers/tests/fauxsis3301.py
@@ -198,7 +198,7 @@ class FauxSIS3301(h5py.Group):
                 "Device name": np.bytes_("SIS 3301"),
                 "Module IP address": np.bytes_("192.168.7.3"),
                 "Module VI path": np.bytes_(
-                    "C:\ACQ II home\Modules\SIS 3301\SIS 3301.vi"
+                    r"C:\ACQ II home\Modules\SIS 3301\SIS 3301.vi"
                 ),
                 "Type": np.bytes_("Data acquisition"),
             }

--- a/bapsflib/_hdf/maps/digitizers/tests/fauxsiscrate.py
+++ b/bapsflib/_hdf/maps/digitizers/tests/fauxsiscrate.py
@@ -557,7 +557,7 @@ class FauxSISCrate(h5py.Group):
                 ),
                 "Device name": np.bytes_("SIS crate"),
                 "Module IP address": np.bytes_("192.168.7.3"),
-                "Module VI path": np.bytes_("Modules\SIS crate\SIS crate.vi"),
+                "Module VI path": np.bytes_(r"Modules\SIS crate\SIS crate.vi"),
                 "Type": np.bytes_("Data acquisition"),
             }
         )

--- a/bapsflib/_hdf/maps/tests/fauxhdfbuilder.py
+++ b/bapsflib/_hdf/maps/tests/fauxhdfbuilder.py
@@ -168,12 +168,17 @@ class FauxHDFBuilder(h5py.File):
 
         # cleanup temporary directory and file
         if isinstance(self.tempdir, tempfile.TemporaryDirectory):
-            if platform.system() == "Windows":
-                # tempfile is already closed, need to remove file
-                os.remove(_path)
-            else:
-                self.tempfile.close()
-            self.tempdir.cleanup()
+            try:
+                if platform.system() == "Windows":
+                    # tempfile is already closed, need to remove file
+                    os.remove(_path)
+                else:
+                    self.tempfile.close()
+
+                self.tempdir.cleanup()
+            except PermissionError:
+                # Temporary file is still being accessed by something
+                pass
 
     def cleanup(self):
         """

--- a/bapsflib/_hdf/utils/tests/__init__.py
+++ b/bapsflib/_hdf/utils/tests/__init__.py
@@ -18,22 +18,17 @@ from bapsflib.utils.tests import BaPSFTestCase
 class TestBase(BaPSFTestCase):
     """Base test class for all test classes here."""
 
-    f = NotImplemented  # type: FauxHDFBuilder
+    def setUp(self) -> None:
+        if not hasattr(self, "_f") or self._f is None:
+            self._f = FauxHDFBuilder()
 
-    @classmethod
-    def setUpClass(cls):
-        # create HDF5 file
-        super().setUpClass()
-        cls.f = FauxHDFBuilder()
+    def tearDown(self) -> None:
+        self.f.cleanup()
+        self._f = None
 
-    def tearDown(self):
-        self.f.reset()
-
-    @classmethod
-    def tearDownClass(cls):
-        # cleanup and close HDF5 file
-        super().tearDownClass()
-        cls.f.cleanup()
+    @property
+    def f(self) -> FauxHDFBuilder:
+        return self._f
 
     @property
     def filename(self) -> str:

--- a/changelog/173.pkg_management.1.rst
+++ b/changelog/173.pkg_management.1.rst
@@ -1,0 +1,2 @@
+Expanded workflow ``test.yml`` to include testing on Python versions
+3.13 and 3.14.

--- a/changelog/173.pkg_management.2.rst
+++ b/changelog/173.pkg_management.2.rst
@@ -1,0 +1,1 @@
+Made Python v3.10 the minimal support version.10

--- a/changelog/173.pkg_management.2.rst
+++ b/changelog/173.pkg_management.2.rst
@@ -1,1 +1,1 @@
-Made Python v3.10 the minimal support version.10
+Made Python v3.10 the minimal support version.

--- a/changelog/173.pkg_management.3.rst
+++ b/changelog/173.pkg_management.3.rst
@@ -1,2 +1,2 @@
-Unfroze the `towncrier` dependency, `towncrier == 22.8.0` ->
-`towncrier >= 22.8.0`.
+Unfroze the ``towncrier`` dependency, ``towncrier == 22.8.0`` ->
+``towncrier >= 22.8.0``.

--- a/changelog/173.pkg_management.3.rst
+++ b/changelog/173.pkg_management.3.rst
@@ -1,0 +1,2 @@
+Unfroze the `towncrier` dependency, `towncrier == 22.8.0` ->
+`towncrier >= 22.8.0`.

--- a/changelog/173.pkg_management.4.rst
+++ b/changelog/173.pkg_management.4.rst
@@ -1,0 +1,1 @@
+Removed the `test-mins` action from the `tests.yml` workflow.

--- a/changelog/173.pkg_management.4.rst
+++ b/changelog/173.pkg_management.4.rst
@@ -1,1 +1,1 @@
-Removed the `test-mins` action from the `tests.yml` workflow.
+Removed the ``test-mins`` action from the ``tests.yml`` workflow.

--- a/changelog/173.removal.1.rst
+++ b/changelog/173.removal.1.rst
@@ -1,0 +1,1 @@
+Removed support for Python 3.9.

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -9,4 +9,4 @@ sphinx-changelog
 sphinx-gallery
 sphinx-hoverxref >= 1.3
 sphinx_rtd_theme
-towncrier == 22.8.0
+towncrier >= 22.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
-python_requires = >=3.9
+python_requires = >=3.10
 zip_safe = false
 packages = find:
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,7 @@ docs =
     sphinx-gallery
     sphinx-hoverxref >= 1.3
     sphinx_rtd_theme
-    towncrier == 22.8.0
+    towncrier >= 22.8.0
 developer =
     # install everything for developers
     %(docs)s


### PR DESCRIPTION
This PR makes the minimum allowable python version 3.10 (i.e. dropping py 3.9).

- Minimum tests now happen on python 3.10
- The `test-mins` workflow is removed altogether
- Testing is expanded to includes tests on python 3.13 and 3.14
- `FauxHDFBuilder.close()` updated to handle `PermissionError` when cleaning up associated temporary directory and HDF5 file.  This is raised if any application/process is still accessing the file.
- Updated `TestBase` to only rely on the `setUp` and `tearDown` methods and NOT the `setUpClass` and `tearDownClass` class methods.
- Unfroze the `towncrier` dependency, `towncrier == 22.8.0` -> `towncrier >= 22.8.0`.