### PR TITLE
Fix `HDFMapControlBMotion` calculation of the `one_config_per_dset` property

### DIFF
--- a/bapsflib/_hdf/maps/controls/bmotion.py
+++ b/bapsflib/_hdf/maps/controls/bmotion.py
@@ -55,6 +55,15 @@ class HDFMapControlBMotion(HDFMapControlTemplate):
         """
         return self._run_config_names
 
+    @property
+    def one_config_per_dset(self) -> bool:
+        """
+        `True` if each control configuration has its own dataset
+        """
+        n_dset = 1
+        n_configs = len(self._configs)
+        return True if n_dset == n_configs else False
+
     def _init_before_build_configs(self):
         self._config_groups = []  # type: List[Group]
         self._run_config_names = tuple()  # type: Tuple[str]

--- a/bapsflib/_hdf/maps/controls/tests/test_bmotion.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_bmotion.py
@@ -871,3 +871,19 @@ class TestBMotion(ControlTestCase):
         with self.assertWarns(HDFMappingWarning):
             _map = self.map
             self.assertNotIn(mg_name, _map.configs)
+
+    def test_one_config_per_dset(self):
+        _conditions = [
+            # (_assert, n_motion_groups)
+            # - n_motion_groups is equivalent to number of configurations
+            (self.assertTrue, 1),
+            (self.assertFalse, 2),
+            (self.assertFalse, 3),
+            (self.assertFalse, 4),
+            (self.assertFalse, 5),
+        ]
+        for _assert, n_motion_groups in _conditions:
+            with self.subTest(_assert=_assert.__name__, n_motion_groups=n_motion_groups):
+                self.mod.knobs.n_motion_groups = n_motion_groups
+
+                _assert(self.map.one_config_per_dset)

--- a/changelog/174.bugfix.1.rst
+++ b/changelog/174.bugfix.1.rst
@@ -1,0 +1,4 @@
+Updated `~bapsflib._hdf.maps.controls.bmotion.HDFMapControlBMotion`
+to override the
+`~bapsflib._hdf.maps.controls.templates.HDFMapControlBMotion.one_config_per_dset`
+property, and fix the one shot per dataset calculation.

--- a/changelog/174.bugfix.1.rst
+++ b/changelog/174.bugfix.1.rst
@@ -1,4 +1,4 @@
 Updated `~bapsflib._hdf.maps.controls.bmotion.HDFMapControlBMotion`
 to override the
-`~bapsflib._hdf.maps.controls.templates.HDFMapControlBMotion.one_config_per_dset`
+`~bapsflib._hdf.maps.controls.templates.HDFMapControlTemplate.one_config_per_dset`
 property, and fix the one shot per dataset calculation.


### PR DESCRIPTION
The standard calculation of `one_config_per_dset` built into `HDFMapControlTemplate` is not valid for `HDFMapControlBMotion`.  As a result, the standard calculation was setting `one_config_per_dset` to `True` when four configs were used during a data run, since the `bmotion` group always contains four datasets.

`bmotion` always contains 4 datasets that every configuration is recorded into; thus, `one_config_per_dset` is only `True` when a single probe drive is used.

To fix this, `HDFMapControlBMotion` overrides the `one_config_per_dset` property.