### PR TITLE
Patch `build_shotnum_dset_relation()` to handle zero padded datasets

### DIFF
--- a/bapsflib/_hdf/utils/helpers.py
+++ b/bapsflib/_hdf/utils/helpers.py
@@ -88,6 +88,12 @@ def build_shotnum_dset_relation(
     # We assume the shot numbers in shotnum and dset are sequential.  If they
     # are not, then something wrong occurred with the ACQ II.
     #
+    # Note: If an digitizer uses multiple configurations during a data
+    #       run, then the HDF5 translator will front fill the datasets
+    #       with zeros for all but the first configuration used.  The
+    #       HDF5 translator "ignorantly" does this to maintain a dataset
+    #       size equivalent to the shot number size.
+    #
     if shotnumkey not in dset.dtype.names:
         raise ValueError(
             f"The expected shot number column '{shotnumkey}' not found in the "

--- a/bapsflib/_hdf/utils/helpers.py
+++ b/bapsflib/_hdf/utils/helpers.py
@@ -128,13 +128,30 @@ def build_shotnum_dset_relation(
         )
 
     dset_shotnum = dset[shotnumkey]
-    if n_configs == 1 and dset_shotnum.size != np.unique(dset_shotnum).size:
+    unique_shotnums = np.unique(dset_shotnum)
+    if dset_shotnum[0] == 0:
+        # A zero shot number should not exist!  This happens when the
+        # HDF5 translator stuffs the front end of a digitizer with zeros.
+
+        nonzero_mask = dset_shotnum != 0
+        dset_shotnum_size = np.count_nonzero(nonzero_mask)
+
+        mask = unique_shotnums != 0
+        unique_shotnums = unique_shotnums[mask]
+        unique_shotnums_size = unique_shotnums.size
+    else:
+        nonzero_mask = np.ones_like(dset_shotnum, dtype=bool)
+        dset_shotnum_size = dset_shotnum.size
+        unique_shotnums_size = unique_shotnums.size
+
+    if n_configs == 1 and dset_shotnum_size != unique_shotnums_size:
         raise ValueError(
             f"HDF5 dataset {dset.name} is indicated to have a single configuration, "
             f"but the shot number column is NOT uniquely filled.  Indicating "
             f"multiple configurations are present."
         )
 
+    err_msg_append = ""
     if config_column is None:
         config_mask = np.ones_like(dset_shotnum, dtype=bool)
     else:
@@ -143,12 +160,14 @@ def build_shotnum_dset_relation(
             dset_config_column == config_column_value.encode()
         )  # type: np.ndarray
 
-        if np.count_nonzero(config_mask) == 0:
-            raise ValueError(
-                f"The config_column_value '{config_column_value}' could not be "
-                f"found in the HDF5 dataset '{dset.name}'.  Valid values are "
-                f"{np.unique(dset_config_column)}."
-            )
+        err_msg_append = f"  Valid values are {np.unique(dset_config_column)}."
+
+    config_mask = np.logical_and(config_mask, nonzero_mask)
+    if np.count_nonzero(config_mask) == 0:
+        raise ValueError(
+            f"The config_column_value '{config_column_value}' could not be "
+            f"found in the HDF5 dataset '{dset.name}'.{err_msg_append}"
+        )
 
     dset_shotnum_subset = dset_shotnum[config_mask]
 

--- a/bapsflib/_hdf/utils/tests/test_helpers.py
+++ b/bapsflib/_hdf/utils/tests/test_helpers.py
@@ -464,11 +464,42 @@ class TestBuildShotnumDsetRelation(TestBase):
         new_header = np.append(np.zeros_like(header), header)
         del mod[dheader_name]
         mod.create_dataset(dheader_name, data=new_header)
+        dheader = mod[dheader_name]
 
-        self.fail("force fail")
+        _conditions = [
+            # (shotnum, expected_shotnums, expected_index)
+            ([1], [1], [100]),
+            ([1, 10], [1, 10], [100, 109]),
+            ([1, 50, 1001], [1, 50], [100, 149]),
+        ]
+        for shotnum, expected_shotnums, expected_index in _conditions:
 
+            shotnum = np.array(shotnum)
+            expected_shotnums = np.array(expected_shotnums)
+            expected_index = np.array(expected_index)
 
+            with self.subTest(
+                shotnum=shotnum,
+                expected_shotnums=expected_shotnums,
+                expected_index=expected_index,
+            ):
+                index, sni = build_shotnum_dset_relation(
+                    shotnum=shotnum,
+                    dset=dheader,
+                    shotnumkey="Shot number",
+                    n_configs=1,
+                    config_column_value=None,
+                    config_column=None,
+                )
 
+                self.assertTrue(
+                    np.allclose(
+                        shotnum[sni],
+                        dheader["Shot number"][index],
+                    )
+                )
+                self.assertTrue(np.allclose(shotnum[sni], expected_shotnums))
+                self.assertTrue(np.allclose(index, expected_index))
 
 
 class TestConditionControls(TestBase):

--- a/bapsflib/_hdf/utils/tests/test_helpers.py
+++ b/bapsflib/_hdf/utils/tests/test_helpers.py
@@ -429,6 +429,47 @@ class TestBuildShotnumDsetRelation(TestBase):
                 )
                 self.assertTrue(np.allclose(kwargs["shotnum"][sni], expected))
 
+    def test_zero_front_padded_dset(self):
+        self.f.remove_all_modules()
+        self.f.add_module(
+            "SIS crate",
+            mod_args={"n_configs": 1, "sn_size": 100, "nt": 1000},
+        )
+
+        # set only one board and channel active
+        mod = self.f.modules["SIS crate"]
+        active_brdch = mod.knobs.active_brdch
+        active_brdch["SIS 3305"][...] = False
+        active_brdch["SIS 3302"][...] = False
+        active_brdch["SIS 3302"][0, 0] = True
+        mod.knobs.active_brdch = active_brdch
+
+        # zero pad datasets
+        config_name = mod.config_names[0]
+        board = 1
+        channel = 1
+        slot = mod.get_slot(board, "SIS 3302")
+        dset_name = f"{config_name} [Slot {slot}: SIS 3302 ch {channel}]"
+        dheader_name = f"{dset_name} headers"
+
+        dset = mod[dset_name]
+        dheader = mod[dheader_name]
+
+        data = dset[...]
+        new_data = np.append(np.zeros_like(data), data, axis=0)
+        del mod[dset_name]
+        mod.create_dataset(dset_name, data=new_data)
+
+        header = dheader[...]
+        new_header = np.append(np.zeros_like(header), header)
+        del mod[dheader_name]
+        mod.create_dataset(dheader_name, data=new_header)
+
+        self.fail("force fail")
+
+
+
+
 
 class TestConditionControls(TestBase):
     """Test Case for condition_controls"""

--- a/changelog/175.bugfix.1.rst
+++ b/changelog/175.bugfix.1.rst
@@ -1,0 +1,2 @@
+Updated `~bapsflib._hdf.utils.helpers.build_shotnum_dset_relation` to
+handle datasets that have been padded with zero rows.


### PR DESCRIPTION
When a data run is performed with multiple `SIS Crate` configurations associated datasets (header and data) in the HDF5 files can get stuffed with leading zero rows (by the HDF5 translator ... we currently think).

For example, let's assume we perform a data run with three sis crate configurations (`config1`, `config2`, and `config3`) that each take 500 shots in sequential order.  The datasets for `config1` will have 500 rows, but the datasets for `config2` and `config3` will have 1000 and 1500 rows respectively.  For `config2` the first 500 rows will be stuffed with zeros and for `config3` the first 1000 rows will be stuffed with zeros.  This is true for both the data and header datasets.

This PR updates `build_shotnum_dset_relation()` to identify when the dataset was stuffed with leading zero rows and exclude those rows when trying to construct the `index` and `sni` arrays for the given/specified `shotnum` array

---

Work first started on PR #172 