### PR TITLE
Expose `bmotion` module to the `maps.controls` namespace

### DIFF
--- a/bapsflib/_hdf/maps/controls/__init__.py
+++ b/bapsflib/_hdf/maps/controls/__init__.py
@@ -15,6 +15,7 @@ Package of control device mapping classes and their constructor
 __all__ = ["ConType", "HDFMapControls"]
 
 from bapsflib._hdf.maps.controls import (
+    bmotion,
     map_controls,
     n5700ps,
     nixyz,

--- a/docs/api_static/bapsflib._hdf.maps.controls.rst
+++ b/docs/api_static/bapsflib._hdf.maps.controls.rst
@@ -12,6 +12,7 @@ Sub-Packages & Modules
 
 .. autosummary::
 
+    bmotion
     map_controls
     n5700ps
     nixyz


### PR DESCRIPTION
PR #154 did not expose the `bapsflib._hdf.controls.bmotion` module to the `bapsflib._hdf.controls.bmotion` namespace.  This fixes that.