### PR TITLE
Create a "Package Features" section in the documentation sidebar

### DIFF
--- a/changelog/181.doc.1.rst
+++ b/changelog/181.doc.1.rst
@@ -1,0 +1,1 @@
+Created the "Package Features" section in the RTD sidebar.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,6 @@ Welcome to bapsflib's documentation!
     Digitizer Mappers <api_static/bapsflib._hdf.maps.digitizers>
     MSI Mappers <api_static/bapsflib._hdf.maps.msi>
     LaPD <api_static/bapsflib.lapd>
-    phys180E <api_static/bapsflib.phys180E>
     Utilities <api_static/bapsflib.utils>
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,8 +25,8 @@ Welcome to bapsflib's documentation!
     Control Mappers <api_static/bapsflib._hdf.maps.controls>
     Digitizer Mappers <api_static/bapsflib._hdf.maps.digitizers>
     MSI Mappers <api_static/bapsflib._hdf.maps.msi>
-    LaPD | `bapsflib.lapd` <api_static/bapsflib.lapd>
-    Utilities | `bapsflib.utils` <api_static/bapsflib.utils>
+    LaPD `bapsflib.lapd` <api_static/bapsflib.lapd>
+    Utilities | :mod:`bapsflib.utils` <api_static/bapsflib.utils>
 
 .. toctree::
     :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,17 @@ Welcome to bapsflib's documentation!
     using_lapd/main
     ./hdfmap/main
 
+.. toctree::
+    :maxdepth: 1
+    :caption: Package Features
+
+    File Mapping <api_static/bapsflib._hdf.maps>
+    Control Mappers <api_static/bapsflib._hdf.maps.controls>
+    Digitizer Mappers <api_static/bapsflib._hdf.maps.digitizers>
+    MSI Mappers <api_static/bapsflib._hdf.maps.msi>
+    LaPD <api_static/bapsflib.lapd>
+    phys180E <api_static/bapsflib.phys180E>
+    Utilities <api_static/bapsflib.utils>
 
 .. toctree::
     :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,8 +25,8 @@ Welcome to bapsflib's documentation!
     Control Mappers <api_static/bapsflib._hdf.maps.controls>
     Digitizer Mappers <api_static/bapsflib._hdf.maps.digitizers>
     MSI Mappers <api_static/bapsflib._hdf.maps.msi>
-    LaPD <api_static/bapsflib.lapd>
-    Utilities <api_static/bapsflib.utils>
+    LaPD | ``bapsflib.lapd`` <api_static/bapsflib.lapd>
+    Utilities | ``bapsflib.utils`` <api_static/bapsflib.utils>
 
 .. toctree::
     :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,8 +25,8 @@ Welcome to bapsflib's documentation!
     Control Mappers <api_static/bapsflib._hdf.maps.controls>
     Digitizer Mappers <api_static/bapsflib._hdf.maps.digitizers>
     MSI Mappers <api_static/bapsflib._hdf.maps.msi>
-    LaPD `bapsflib.lapd` <api_static/bapsflib.lapd>
-    Utilities | :mod:`bapsflib.utils` <api_static/bapsflib.utils>
+    LaPD | bapsflib.lapd <api_static/bapsflib.lapd>
+    Utilities | bapsflib.utils <api_static/bapsflib.utils>
 
 .. toctree::
     :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,8 +25,8 @@ Welcome to bapsflib's documentation!
     Control Mappers <api_static/bapsflib._hdf.maps.controls>
     Digitizer Mappers <api_static/bapsflib._hdf.maps.digitizers>
     MSI Mappers <api_static/bapsflib._hdf.maps.msi>
-    LaPD \| ``bapsflib.lapd`` <api_static/bapsflib.lapd>
-    Utilities \| ``bapsflib.utils`` <api_static/bapsflib.utils>
+    LaPD | `bapsflib.lapd` <api_static/bapsflib.lapd>
+    Utilities | `bapsflib.utils` <api_static/bapsflib.utils>
 
 .. toctree::
     :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,8 +25,8 @@ Welcome to bapsflib's documentation!
     Control Mappers <api_static/bapsflib._hdf.maps.controls>
     Digitizer Mappers <api_static/bapsflib._hdf.maps.digitizers>
     MSI Mappers <api_static/bapsflib._hdf.maps.msi>
-    LaPD | ``bapsflib.lapd`` <api_static/bapsflib.lapd>
-    Utilities | ``bapsflib.utils`` <api_static/bapsflib.utils>
+    LaPD \| ``bapsflib.lapd`` <api_static/bapsflib.lapd>
+    Utilities \| ``bapsflib.utils`` <api_static/bapsflib.utils>
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
This PR creates a "Package Features" section in the sidebar of the RTD.  This section highlights key root level sub-modules.