### PR TITLE
Improve typing annotation of the `File` classes.

### DIFF
--- a/bapsflib/_hdf/utils/file.py
+++ b/bapsflib/_hdf/utils/file.py
@@ -10,16 +10,26 @@
 #
 """Module containing the main HDF5 `~bapsflib._hdf.utils.file.File` class."""
 
+from __future__ import annotations
+
 __all__ = ["File"]
 
 import h5py
 import os
 import warnings
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 from bapsflib._hdf.maps import HDFMapControls, HDFMapDigitizers, HDFMapMSI, HDFMapper
 from bapsflib.utils.warnings import BaPSFWarning, HDFMappingWarning
+
+if TYPE_CHECKING:
+    # This is done for typing purposes only.
+    # An actual import would cause cyclical imports.
+    from bapsflib._hdf.utils.hdfreadcontrols import HDFReadControls
+    from bapsflib._hdf.utils.hdfreadmsi import HDFReadMSI
+    from bapsflib._hdf.utils.hdfoverview import HDFOverview
+    from bapsflib._hdf.utils.hdfreaddata import HDFReadData
 
 
 class File(h5py.File):
@@ -149,7 +159,7 @@ class File(h5py.File):
         return self.file_map.msi
 
     @property
-    def overview(self):
+    def overview(self) -> HDFOverview:
         """
         HDF5 file overview. (:class:`~.hdfoverview.HDFOverview`)
         """
@@ -270,19 +280,19 @@ class File(h5py.File):
 
     def read_controls(
         self,
-        controls: List[Union[str, Tuple[str, Any]]],
+        controls: List[str | Tuple[str, Any]],
         shotnum=slice(None),
         intersection_set=True,
         silent=False,
         **kwargs,
-    ):
+    ) -> HDFReadControls:
         """
         Reads data from control device datasets.  See
         :class:`~.hdfreadcontrols.HDFReadControls` for more detail.
 
         Parameters
         ----------
-        controls : List[Union[str, Tuple[str, Any]]]
+        controls : List[str | Tuple[str, Any]]
             A list of strings and/or 2-element tuples indicating the
             control device(s).  If a control device has only one
             configuration then only the device name ``'control'`` needs
@@ -292,7 +302,7 @@ class File(h5py.File):
             ``('control', 'config')`` in the list. (see
             :func:`~.helpers.condition_controls` for details)
 
-        shotnum : Union[int, list(int), slice(), numpy.array], optional
+        shotnum : int | list(int) | slice() | numpy.array, optional
             HDF5 file shot number(s) indicating data entries to be
             extracted
 
@@ -380,7 +390,7 @@ class File(h5py.File):
         intersection_set=True,
         silent=False,
         **kwargs,
-    ):
+    ) -> HDFReadData:
         """
         Reads data from digitizer datasets and attaches control device
         data when requested. (see :class:`.hdfreaddata.HDFReadData`
@@ -394,10 +404,10 @@ class File(h5py.File):
         channel : `int`
             digitizer channel number
 
-        index : Union[int, list(int), slice(), numpy.array], optional
+        index : int | list(int) | slice() | numpy.array, optional
             dataset row index
 
-        shotnum : Union[int, list(int), slice(), numpy.array], optional
+        shotnum : int | list(int) | slice() | numpy.array, optional
             HDF5 global shot number
 
         digitizer : `str`, optional
@@ -413,7 +423,7 @@ class File(h5py.File):
             `True` to keep digitizer signal in bits, `False` (default)
             to convert digitizer signal to voltage
 
-        add_controls : List[Union[str, Tuple[str, Any]]], optional
+        add_controls : List[str | Tuple[str, Any]], optional
             A list of strings and/or 2-element tuples indicating the
             control device(s).  If a control device has only one
             configuration then only the device name ``'control'`` needs
@@ -508,7 +518,7 @@ class File(h5py.File):
 
         return data
 
-    def read_msi(self, msi_diag: str, silent=False, **kwargs):
+    def read_msi(self, msi_diag: str, silent=False, **kwargs) -> HDFReadMSI:
         """
         Reads data from MSI Diagnostic datasets.  See
         :class:`~.hdfreadmsi.HDFReadMSI` for more detail.

--- a/bapsflib/_hdf/utils/file.py
+++ b/bapsflib/_hdf/utils/file.py
@@ -26,10 +26,10 @@ from bapsflib.utils.warnings import BaPSFWarning, HDFMappingWarning
 if TYPE_CHECKING:
     # This is done for typing purposes only.
     # An actual import would cause cyclical imports.
-    from bapsflib._hdf.utils.hdfreadcontrols import HDFReadControls
-    from bapsflib._hdf.utils.hdfreadmsi import HDFReadMSI
     from bapsflib._hdf.utils.hdfoverview import HDFOverview
+    from bapsflib._hdf.utils.hdfreadcontrols import HDFReadControls
     from bapsflib._hdf.utils.hdfreaddata import HDFReadData
+    from bapsflib._hdf.utils.hdfreadmsi import HDFReadMSI
 
 
 class File(h5py.File):

--- a/bapsflib/lapd/_hdf/file.py
+++ b/bapsflib/lapd/_hdf/file.py
@@ -10,12 +10,21 @@
 #
 """Module containing the HDF5 reader for LaPD generated files."""
 
+from __future__ import annotations
+
 __all__ = ["File"]
 
 import h5py
 
+from typing import TYPE_CHECKING
+
 from bapsflib._hdf.utils.file import File as BaseFile
 from bapsflib.lapd._hdf.mapper import LaPDMapper
+
+if TYPE_CHECKING:
+    # This is done for typing purposes only.
+    # An actual import would cause cyclical imports.
+    from bapsflib.lapd._hdf.lapdoverview import LaPDOverview
 
 
 class File(BaseFile):
@@ -88,7 +97,7 @@ class File(BaseFile):
         return self._file_map
 
     @property
-    def overview(self):
+    def overview(self) -> LaPDOverview:
         """
         LaPD HDF5 file overview. (:class:`~.lapdoverview.LaPDOverview`)
         """

--- a/bapsflib/lapd/_hdf/file.py
+++ b/bapsflib/lapd/_hdf/file.py
@@ -65,7 +65,7 @@ class File(BaseFile):
             digitizer_path="Raw data + config",
             msi_path="MSI",
             silent=silent,
-            **kwargs
+            **kwargs,
         )
 
     def _build_info(self):

--- a/changelog/182.trivial.1.rst
+++ b/changelog/182.trivial.1.rst
@@ -1,0 +1,6 @@
+Added return annotations for key `~bapsflib._hdf.utils.file.File`
+methods, `~bapsflib._hdf.utils.file.File.overview`,
+`~bapsflib._hdf.utils.file.File.read_controls`,
+`~bapsflib._hdf.utils.file.File.read_data`, and
+`~bapsflib._hdf.utils.file.File.read_msi`.  This was done on both
+`~bapsflib._hdf.utils.file.File` and `~bapsflib.lapd._hdf.file.File`.

--- a/changelog/182.trivial.1.rst
+++ b/changelog/182.trivial.1.rst
@@ -3,4 +3,4 @@ methods, `~bapsflib._hdf.utils.file.File.overview`,
 `~bapsflib._hdf.utils.file.File.read_controls`,
 `~bapsflib._hdf.utils.file.File.read_data`, and
 `~bapsflib._hdf.utils.file.File.read_msi`.  This was done on both
-`~bapsflib._hdf.utils.file.File` and `~bapsflib.lapd._hdf.file.File`.
+`bapsflib._hdf.utils.file.File` and `bapsflib.lapd._hdf.file.File`.

--- a/changelog/182.trivial.2.rst
+++ b/changelog/182.trivial.2.rst
@@ -1,0 +1,2 @@
+Replaced some instances of the ``Union[]`` annotation with the newer
+pipe ``|`` notation.


### PR DESCRIPTION
This improve typing annotations for the `File` classes, `bapsflib._hdf.utils.file.File` and `bapsflib.lapd._hdf.file.File`.

- Replaces usage of `Union[]` with the pipe `|`
- Adds explicit return annotations for `overview`, `read_data()`, `read_controls()`, and `read_msi()`.