### PR TITLE
Add `__str__` and `__repr__` dunders for `HDFMapDigitizers` and `HDFMapControls`

### DIFF
--- a/bapsflib/_hdf/maps/controls/map_controls.py
+++ b/bapsflib/_hdf/maps/controls/map_controls.py
@@ -27,6 +27,7 @@ from bapsflib._hdf.maps.controls.templates import (
     HDFMapControlTemplate,
 )
 from bapsflib._hdf.maps.controls.waveform import HDFMapControlWaveform
+from bapsflib.utils import TableDisplay
 from bapsflib.utils.exceptions import HDFMappingError
 
 
@@ -91,6 +92,42 @@ class HDFMapControls(dict):
 
         # Build the self dictionary
         dict.__init__(self, self.__build_dict)
+
+    def __str__(self):
+        # gather information
+        rows = [
+            [
+                "Control",
+                "Configuration",
+                "Shot Num. Range",
+                "Readout Data Fields",
+            ],
+        ]
+        for control_name, _map in self.items():
+            control_name_added = False
+            for cname, config in _map.configs.items():
+                control_entry = "" if control_name_added else f"'{control_name}'"
+                rows.append(
+                    [
+                        control_entry,
+                        f"'{cname}'",
+                        '??',
+                        str(tuple(config["state values"].keys())),
+                    ]
+                )
+
+                control_name_added = True
+
+        table_display = TableDisplay(rows=rows[1:], headers=rows[0])
+        table_display.auto_insert_horizontal_dividers(on_columns=[0])
+        table_str = table_display.table_string()
+
+        return table_str
+
+    def __repr__(self):
+        _repr = super().__repr__()
+        _repr += f"\n\n{self.__str__()}"
+        return _repr
 
     @property
     def mappable_devices(self) -> Tuple[str, ...]:

--- a/bapsflib/_hdf/maps/controls/map_controls.py
+++ b/bapsflib/_hdf/maps/controls/map_controls.py
@@ -94,6 +94,10 @@ class HDFMapControls(dict):
         dict.__init__(self, self.__build_dict)
 
     def __str__(self):
+        if len(self) == 0:
+            # no controls mapped
+            return ""
+
         # gather information
         rows = [
             [

--- a/bapsflib/_hdf/maps/controls/map_controls.py
+++ b/bapsflib/_hdf/maps/controls/map_controls.py
@@ -115,7 +115,7 @@ class HDFMapControls(dict):
                     [
                         control_entry,
                         f"'{cname}'",
-                        '??',
+                        "??",
                         str(tuple(config["state values"].keys())),
                     ]
                 )

--- a/bapsflib/_hdf/maps/controls/tests/test_map_controls.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_map_controls.py
@@ -158,7 +158,3 @@ class TestHDFMapControls(ut.TestCase):
 
         # check attribute types
         self.assertIsInstance(_map.mappable_devices, tuple)
-
-
-if __name__ == "__main__":
-    ut.main()

--- a/bapsflib/_hdf/maps/controls/tests/test_map_controls.py
+++ b/bapsflib/_hdf/maps/controls/tests/test_map_controls.py
@@ -145,6 +145,40 @@ class TestHDFMapControls(ut.TestCase):
         self.assertIn("6K Compumotor", _map)
         self.assertNotIn("Waveform", _map)
 
+    def test__str__(self):
+        # add controls to the Faux HDF5 file
+        self.f.add_module("6K Compumotor", {"n_configs": 2})
+        self.f.add_module("Waveform", {})
+
+        # remap the file
+        _map = self.map
+
+        expected = (
+            "| Control         | Configuration | Shot Num. Range | Readout Data Fields                       |\n"
+            "+-----------------+---------------+-----------------+-------------------------------------------+\n"
+            "| '6K Compumotor' | '1'           | ??              | ('xyz', 'ptip_rot_theta', 'ptip_rot_phi') |\n"
+            "|                 | '2'           | ??              | ('xyz', 'ptip_rot_theta', 'ptip_rot_phi') |\n"
+            "| --------------- | ------------- | --------------- | ----------------------------------------- |\n"
+            "| 'Waveform'      | 'config01'    | ??              | ('FREQ',)                                 |\n"
+        )
+        self.assertEqual(_map.__str__(), expected)
+
+    def test__str__no_controls(self):
+        # the faux modules start without any controls
+        _map = self.map
+        self.assertEqual(_map.__str__(), "")
+
+    def test__repr__(self):
+        # add controls to the Faux HDF5 file
+        self.f.add_module("6K Compumotor", {})
+        self.f.add_module("Waveform", {})
+
+        # remap the file
+        _map = self.map
+
+        expected = f"{dict.__repr__(_map)}\n\n{_map.__str__()}"
+        self.assertEqual(_map.__repr__(), expected)
+
     def assertBasics(self, _map: HDFMapControls):
         # mapped object is a dictionary
         self.assertIsInstance(_map, dict)

--- a/bapsflib/_hdf/maps/digitizers/map_digis.py
+++ b/bapsflib/_hdf/maps/digitizers/map_digis.py
@@ -69,6 +69,10 @@ class HDFMapDigitizers(dict):
         dict.__init__(self, self.__build_dict)
 
     def __str__(self):
+        if len(self) == 0:
+            # no digitizers mapped
+            return ""
+
         # gather information
         rows = [
             [

--- a/bapsflib/_hdf/maps/digitizers/map_digis.py
+++ b/bapsflib/_hdf/maps/digitizers/map_digis.py
@@ -107,7 +107,7 @@ class HDFMapDigitizers(dict):
                                 cname_entry,
                                 adc_entry,
                                 str((board, channels)),
-                                '??',
+                                "??",
                                 str(_setup["nt"]),
                             ]
                         )

--- a/bapsflib/_hdf/maps/digitizers/map_digis.py
+++ b/bapsflib/_hdf/maps/digitizers/map_digis.py
@@ -67,6 +67,83 @@ class HDFMapDigitizers(dict):
         # Build the self dictionary
         dict.__init__(self, self.__build_dict)
 
+    def __str__(self):
+        # gather information
+        rows = [
+            [
+                "Digitizer",
+                "Configuration",
+                "ADC",
+                "(board, [channel, ...])",
+                "Shot Num. Range",
+                "nt",
+            ],
+        ]
+        for digi_name, _map in self.items():
+            digi_name_added = False
+            for cname, config in _map.configs.items():
+                cname_added = False
+                if not config["active"]:
+                    continue
+
+                for adc_ii, adc in enumerate(config["adc"]):
+                    adc_added = False
+                    for connection_ii, connection in enumerate(config[adc]):
+                        board = connection[0]
+                        channels = connection[1]
+                        _setup = connection[2]
+
+                        digi_entry = "" if digi_name_added else digi_name
+                        cname_entry = "" if cname_added else cname
+                        adc_entry = "" if adc_added else adc
+                        rows.append(
+                            [
+                                digi_entry,
+                                cname_entry,
+                                adc_entry,
+                                str((board, channels)),
+                                '??',
+                                str(_setup["nt"]),
+                            ]
+                        )
+
+                        digi_name_added = True
+                        cname_added = True
+                        adc_added = True
+
+        max_cell_sizes = [1] * len(rows[0])
+        for row in rows:
+            for ii in range(len(max_cell_sizes)):
+                max_cell_sizes[ii] = max(max_cell_sizes[ii], len(row[ii]) + 2)
+
+        table_str = ""
+        for ii, row in enumerate(rows):
+            table_str += (
+                f"| {row[0]:<{max_cell_sizes[0]}} "
+                f"| {row[1]:<{max_cell_sizes[1]}} "
+                f"| {row[2]:<{max_cell_sizes[2]}} "
+                f"| {row[3]:<{max_cell_sizes[3]}} "
+                f"| {row[4]:<{max_cell_sizes[4]}} "
+                f"| {row[5]:<{max_cell_sizes[5]}} |\n"
+            )
+
+            if ii == 0:
+                table_str += (
+                    f"+{'-' * (max_cell_sizes[0] + 2)}"
+                    f"+{'-' * (max_cell_sizes[1] + 2)}"
+                    f"+{'-' * (max_cell_sizes[2] + 2)}"
+                    f"+{'-' * (max_cell_sizes[3] + 2)}"
+                    f"+{'-' * (max_cell_sizes[4] + 2)}"
+                    f"+{'-' * (max_cell_sizes[5] + 2)}+\n"
+                )
+
+        return table_str
+
+    def __repr__(self):
+        _repr = super().__repr__()
+        _repr += f"\n\n{self.__str__()}"
+        return _repr
+
     @property
     def mappable_devices(self) -> Tuple[str, ...]:
         """

--- a/bapsflib/_hdf/maps/digitizers/map_digis.py
+++ b/bapsflib/_hdf/maps/digitizers/map_digis.py
@@ -19,6 +19,7 @@ from typing import Dict, Tuple
 from bapsflib._hdf.maps.digitizers.sis3301 import HDFMapDigiSIS3301
 from bapsflib._hdf.maps.digitizers.siscrate import HDFMapDigiSISCrate
 from bapsflib._hdf.maps.digitizers.templates import HDFMapDigiTemplate
+from bapsflib.utils import TableDisplay
 from bapsflib.utils.exceptions import HDFMappingError
 
 
@@ -111,31 +112,9 @@ class HDFMapDigitizers(dict):
                         cname_added = True
                         adc_added = True
 
-        max_cell_sizes = [1] * len(rows[0])
-        for row in rows:
-            for ii in range(len(max_cell_sizes)):
-                max_cell_sizes[ii] = max(max_cell_sizes[ii], len(row[ii]) + 2)
-
-        table_str = ""
-        for ii, row in enumerate(rows):
-            table_str += (
-                f"| {row[0]:<{max_cell_sizes[0]}} "
-                f"| {row[1]:<{max_cell_sizes[1]}} "
-                f"| {row[2]:<{max_cell_sizes[2]}} "
-                f"| {row[3]:<{max_cell_sizes[3]}} "
-                f"| {row[4]:<{max_cell_sizes[4]}} "
-                f"| {row[5]:<{max_cell_sizes[5]}} |\n"
-            )
-
-            if ii == 0:
-                table_str += (
-                    f"+{'-' * (max_cell_sizes[0] + 2)}"
-                    f"+{'-' * (max_cell_sizes[1] + 2)}"
-                    f"+{'-' * (max_cell_sizes[2] + 2)}"
-                    f"+{'-' * (max_cell_sizes[3] + 2)}"
-                    f"+{'-' * (max_cell_sizes[4] + 2)}"
-                    f"+{'-' * (max_cell_sizes[5] + 2)}+\n"
-                )
+        table_display = TableDisplay(rows=rows[1:], headers=rows[0])
+        table_display.auto_insert_horizontal_dividers(on_columns=[0, 1])
+        table_str = table_display.table_string()
 
         return table_str
 

--- a/bapsflib/_hdf/maps/digitizers/map_digis.py
+++ b/bapsflib/_hdf/maps/digitizers/map_digis.py
@@ -94,9 +94,9 @@ class HDFMapDigitizers(dict):
                         channels = connection[1]
                         _setup = connection[2]
 
-                        digi_entry = "" if digi_name_added else digi_name
-                        cname_entry = "" if cname_added else cname
-                        adc_entry = "" if adc_added else adc
+                        digi_entry = "" if digi_name_added else f"'{digi_name}'"
+                        cname_entry = "" if cname_added else f"'{cname}'"
+                        adc_entry = "" if adc_added else f"'{adc}'"
                         rows.append(
                             [
                                 digi_entry,

--- a/bapsflib/_hdf/maps/digitizers/sis3301.py
+++ b/bapsflib/_hdf/maps/digitizers/sis3301.py
@@ -605,6 +605,7 @@ class HDFMapDigiSIS3301(HDFMapDigiTemplate):
             elif brd < 0:
                 warn("Board number is less than 0.", HDFMappingWarning)
                 continue
+            brd = int(brd)
 
             # ensure there's no duplicate board numbers
             if brd in [sconn[0] for sconn in conn]:
@@ -651,6 +652,7 @@ class HDFMapDigiSIS3301(HDFMapDigiTemplate):
                 elif ch < 0:
                     warn("Channel number is less than 0.", HDFMappingWarning)
                     continue
+                ch = int(ch)
 
                 # define list of channels
                 chs.append(ch)

--- a/bapsflib/_hdf/maps/digitizers/tests/test_map_digis.py
+++ b/bapsflib/_hdf/maps/digitizers/tests/test_map_digis.py
@@ -138,6 +138,47 @@ class TestHDFMapDigitizers(ut.TestCase):
         self.assertIn("SIS crate", _map)
         self.assertNotIn("SIS 3301", _map)
 
+    def test__str__(self):
+        # add digis to the Faux HDF5 file
+        self.f.add_module("SIS 3301", {})
+        self.f.add_module("SIS crate", {"n_configs": 2})
+        cnames = self.f.modules["SIS crate"].config_names
+        self.f.modules["SIS crate"].knobs.active_config = cnames
+
+        # remap the file
+        _map = self.map
+
+        expected = (
+            "| Digitizer   | Configuration | ADC        | (board, [channel, ...]) | Shot Num. Range | nt    |\n"
+            "+-------------+---------------+------------+-------------------------+-----------------+-------+\n"
+            "| 'SIS 3301'  | 'config01'    | 'SIS 3301' | (0, (0,))               | ??              | 10000 |\n"
+            "| ----------- | ------------- | ---------- | ----------------------- | --------------- | ----- |\n"
+            "| 'SIS crate' | 'config01'    | 'SIS 3302' | (1, (1,))               | ??              | 10000 |\n"
+            "|             |               | 'SIS 3305' | (1, (1,))               | ??              | 10000 |\n"
+            "|             | ------------- | ---------- | ----------------------- | --------------- | ----- |\n"
+            "|             | 'config02'    | 'SIS 3302' | (1, (1,))               | ??              | 10000 |\n"
+            "|             |               | 'SIS 3305' | (1, (1,))               | ??              | 10000 |\n"
+        )
+        self.assertEqual(_map.__str__(), expected)
+
+    def test__str__no_digis(self):
+        # the faux modules start without any digitizers
+        _map = self.map
+        self.assertEqual(_map.__str__(), "")
+
+    def test__repr__(self):
+        # add digis to the Faux HDF5 file
+        self.f.add_module("SIS 3301", {})
+        self.f.add_module("SIS crate", {"n_configs": 2})
+        cnames = self.f.modules["SIS crate"].config_names
+        self.f.modules["SIS crate"].knobs.active_config = cnames
+
+        # remap the file
+        _map = self.map
+
+        expected = f"{dict.__repr__(_map)}\n\n{_map.__str__()}"
+        self.assertEqual(_map.__repr__(), expected)
+
     def assertBasics(self, _map: HDFMapDigitizers):
         # mapped object is a dictionary
         self.assertIsInstance(_map, dict)
@@ -158,7 +199,3 @@ class TestHDFMapDigitizers(ut.TestCase):
             sorted(list(_map.mappable_devices)),
             sorted(list(_map._defined_mapping_classes)),
         )
-
-
-if __name__ == "__main__":
-    ut.main()

--- a/bapsflib/_hdf/maps/digitizers/tests/test_map_digis.py
+++ b/bapsflib/_hdf/maps/digitizers/tests/test_map_digis.py
@@ -161,6 +161,24 @@ class TestHDFMapDigitizers(ut.TestCase):
         )
         self.assertEqual(_map.__str__(), expected)
 
+    def test__str__w_non_active_config(self):
+        # add digis to the Faux HDF5 file
+        self.f.add_module("SIS 3301", {})
+        self.f.add_module("SIS crate", {"n_configs": 2})
+
+        # remap the file
+        _map = self.map
+
+        expected = (
+            "| Digitizer   | Configuration | ADC        | (board, [channel, ...]) | Shot Num. Range | nt    |\n"
+            "+-------------+---------------+------------+-------------------------+-----------------+-------+\n"
+            "| 'SIS 3301'  | 'config01'    | 'SIS 3301' | (0, (0,))               | ??              | 10000 |\n"
+            "| ----------- | ------------- | ---------- | ----------------------- | --------------- | ----- |\n"
+            "| 'SIS crate' | 'config01'    | 'SIS 3302' | (1, (1,))               | ??              | 10000 |\n"
+            "|             |               | 'SIS 3305' | (1, (1,))               | ??              | 10000 |\n"
+        )
+        self.assertEqual(_map.__str__(), expected)
+
     def test__str__no_digis(self):
         # the faux modules start without any digitizers
         _map = self.map

--- a/bapsflib/utils/__init__.py
+++ b/bapsflib/utils/__init__.py
@@ -183,7 +183,7 @@ class TableDisplay:
                 divider = []
                 for jj in range(self.ncols):
                     _string = " " if jj < on_column else "-"
-                    divider.append(_string * self.cell_widths[jj])
+                    divider.append(_string * (self.cell_widths[jj] - 2))
 
                 _rows_w_dividers.insert(ii, divider)
                 break

--- a/bapsflib/utils/__init__.py
+++ b/bapsflib/utils/__init__.py
@@ -12,14 +12,14 @@
 Package of package utility / helper functionality.
 """
 
-__all__ = []
+__all__ = ["TableDisplay"]
 
-from typing import Union
+from typing import List
 
 from bapsflib.utils import decorators, exceptions, warnings
 
 
-def _bytes_to_str(string: Union[bytes, str]) -> str:
+def _bytes_to_str(string: bytes | str) -> str:
     """Helper to convert a bytes literal to a utf-8 string."""
     if isinstance(string, str):
         return string
@@ -31,3 +31,113 @@ def _bytes_to_str(string: Union[bytes, str]) -> str:
             return str(string, "cp1252")
 
     raise TypeError(f"Argument 'string' is not of type str or bytes, got {type(string)}.")
+
+
+class TableDisplay:
+    def __init__(self, rows: List[List[str]], headers: List[str] | None = None):
+        self._rows = rows
+        self._rows_w_dividers = None
+        self._headers = headers
+
+        if not isinstance(rows, list):
+            raise TypeError("rows must be a list")
+
+        for row in rows:
+            if not isinstance(row, list):
+                raise TypeError("row must be a list")
+
+            if not all(isinstance(entry, str) for entry in row):
+                raise ValueError()
+
+        if isinstance(headers, list):
+            if len(headers) != self.ncols:
+                raise ValueError("headers must be a list")
+
+            if not all(isinstance(entry, str) for entry in headers):
+                raise ValueError()
+        elif headers is not None:
+            raise TypeError("headers must be a list or None")
+
+        self._cell_widths = self._calc_max_cell_widths()
+
+    @property
+    def cell_widths(self) -> List[int]:
+        return self._cell_widths
+
+    @property
+    def headers(self) -> List[str]:
+        return self._headers
+
+    @property
+    def rows(self) -> List[List[str]]:
+        return self._rows
+
+    @property
+    def nrows(self) -> int:
+        return len(self._rows)
+
+    @property
+    def ncols(self) -> int:
+        return len(self._rows[0])
+
+    def _calc_max_cell_widths(self):
+        max_cel_widths = [len(entry) + 2 for entry in self.headers]
+        for row in self.rows:
+            for ii in range(len(max_cel_widths)):
+                max_cel_widths[ii] = max(max_cel_widths[ii], len(row[ii]) + 2)
+
+        return max_cel_widths
+
+    def auto_insert_horizontal_dividers(self, on_columns: List[int] | None = None):
+        if on_columns is None:
+            return
+
+        if not isinstance(on_columns, list):
+            raise TypeError("on_column must be a int")
+
+        if not all(isinstance(entry, int) for entry in on_columns):
+            raise TypeError("All `on_column` entries must be a int.")
+
+        on_columns = [val for val in set(on_columns) if 0 <= val < self.ncols]
+        if len(on_columns) == 0:
+            return
+
+        _rows_w_dividers = self.rows.copy()
+
+        for ii in range(self.nrows - 1, 0, -1):
+            row = _rows_w_dividers[ii]
+
+            for on_column in on_columns:
+                if row[on_column] == "":
+                    continue
+
+                divider = []
+                for jj in range(self.ncols):
+                    _string = " " if jj < on_column else "-"
+                    divider.append(_string * self.cell_widths[jj])
+
+                _rows_w_dividers.insert(ii, divider)
+                break
+
+        self._rows_w_dividers = _rows_w_dividers
+
+    def table_string(self) -> str:
+
+        table_string = ""
+
+        if self.headers is not None:
+            for ii, entry in enumerate(self.headers):
+                table_string += f"| {entry:<{self.cell_widths[ii]}} "
+            table_string += "|\n"
+
+            for ii, entry in enumerate(self.headers):
+                table_string += f"+{'-' * (self.cell_widths[ii] + 2)}"
+            table_string += "+\n"
+
+        rows = self.rows if self._rows_w_dividers is None else self._rows_w_dividers
+        for row in rows:
+            for ii, entry in enumerate(row):
+                table_string += f"| {entry:<{self.cell_widths[ii]}} "
+            table_string += "|\n"
+
+        return table_string

--- a/bapsflib/utils/__init__.py
+++ b/bapsflib/utils/__init__.py
@@ -47,10 +47,9 @@ class TableDisplay:
         ----------
         rows : List[List[str]]
             List of table rows where each row is a list of strings being
-            the contents of the associated row-column cell.
-
-            For example, ``rows[4][3]`` would be the cell contents of
-            row 5 and column 4.
+            the contents of the associated row-column cell.  For
+            example, ``rows[4][3]`` would be the cell contents of row 5
+            and column 4.
 
         headers : List[str]
             List of strings specifying the table column headers.  `None`

--- a/bapsflib/utils/__init__.py
+++ b/bapsflib/utils/__init__.py
@@ -60,23 +60,33 @@ class TableDisplay:
         self._headers = headers
 
         if not isinstance(rows, list):
-            raise TypeError("rows must be a list")
+            raise TypeError(
+                f"Argument `rows` must be a list of lists, got type {type(rows)}."
+            )
 
         for row in rows:
             if not isinstance(row, list):
-                raise TypeError("row must be a list")
+                raise TypeError(
+                    f"Argument `rows` must be a list of lists, got type {type(rows)}."
+                )
 
             if not all(isinstance(entry, str) for entry in row):
-                raise ValueError()
+                raise ValueError("All entries in argument `rows` bust be a string.")
 
         if isinstance(headers, list):
             if len(headers) != self.ncols:
-                raise ValueError("headers must be a list")
+                raise ValueError(
+                    "Argument `headers` does NOT contain the same number of "
+                    f"columns ({len(headers)}) as the `rows` argument ({self.ncols}).)"
+                )
 
             if not all(isinstance(entry, str) for entry in headers):
-                raise ValueError()
+                raise ValueError("All entries in argument `headers` bust be a string.")
         elif headers is not None:
-            raise TypeError("headers must be a list or None")
+            raise TypeError(
+                f"Argument `headers` must be a list of string or None, "
+                f"got type {type(headers)}."
+            )
 
         self._cell_widths = self._calc_max_cell_widths()
 

--- a/bapsflib/utils/__init__.py
+++ b/bapsflib/utils/__init__.py
@@ -9,7 +9,7 @@
 #   license terms and contributor agreement.
 #
 """
-Package of developer utilities.
+Package of package utility / helper functionality.
 """
 
 __all__ = []

--- a/bapsflib/utils/__init__.py
+++ b/bapsflib/utils/__init__.py
@@ -88,9 +88,7 @@ class TableDisplay:
 
         return max_cel_widths
 
-    def auto_insert_horizontal_dividers(self, on_columns: List[int] | None = None):
-        if on_columns is None:
-            return
+    def auto_insert_horizontal_dividers(self, on_columns: List[int]):
 
         if not isinstance(on_columns, list):
             raise TypeError("on_column must be a int")

--- a/bapsflib/utils/__init__.py
+++ b/bapsflib/utils/__init__.py
@@ -190,17 +190,17 @@ class TableDisplay:
 
         if self.headers is not None:
             for ii, entry in enumerate(self.headers):
-                table_string += f"| {entry:<{self.cell_widths[ii]}} "
+                table_string += f"| {entry:<{self.cell_widths[ii] - 2}} "
             table_string += "|\n"
 
             for ii, entry in enumerate(self.headers):
-                table_string += f"+{'-' * (self.cell_widths[ii] + 2)}"
+                table_string += f"+{'-' * (self.cell_widths[ii])}"
             table_string += "+\n"
 
         rows = self.rows if self._rows_w_dividers is None else self._rows_w_dividers
         for row in rows:
             for ii, entry in enumerate(row):
-                table_string += f"| {entry:<{self.cell_widths[ii]}} "
+                table_string += f"| {entry:<{self.cell_widths[ii] - 2}} "
             table_string += "|\n"
 
         return table_string

--- a/bapsflib/utils/__init__.py
+++ b/bapsflib/utils/__init__.py
@@ -124,12 +124,16 @@ class TableDisplay:
         Scans `rows` and `headers` to determine the maximum cell width
         for each column.
         """
-        max_cel_widths = [len(entry) + 2 for entry in self.headers]
-        for row in self.rows:
-            for ii in range(len(max_cel_widths)):
-                max_cel_widths[ii] = max(max_cel_widths[ii], len(row[ii]) + 2)
+        if self.headers is None:
+            max_cell_widths = [1] * self.ncols
+        else:
+            max_cell_widths = [len(entry) + 2 for entry in self.headers]
 
-        return max_cel_widths
+        for row in self.rows:
+            for ii in range(len(max_cell_widths)):
+                max_cell_widths[ii] = max(max_cell_widths[ii], len(row[ii]) + 2)
+
+        return max_cell_widths
 
     def auto_insert_horizontal_dividers(self, on_columns: List[int]):
         """

--- a/bapsflib/utils/__init__.py
+++ b/bapsflib/utils/__init__.py
@@ -34,7 +34,27 @@ def _bytes_to_str(string: bytes | str) -> str:
 
 
 class TableDisplay:
+    """
+    Class designed to generated the brief summary tables used in the
+    ``__str__`` and ``__repr__`` methods of
+    `~bapsflib._hdf.maps.digitizers.map_digis.HDFMapDigitizers` and
+    `~bapsflib._hdf.maps.controls.map_controls.HDFMapControls`.
+    """
     def __init__(self, rows: List[List[str]], headers: List[str] | None = None):
+        """
+        Parameters
+        ----------
+        rows : List[List[str]]
+            List of table rows where each row is a list of strings being
+            the contents of the associated row-column cell.
+
+            For example, ``rows[4][3]`` would be the cell contents of
+            row 5 and column 4.
+
+        headers : List[str]
+            List of strings specifying the table column headers.  `None`
+            if table has no headers. (DEFAULT: `None`)
+        """
         self._rows = rows
         self._rows_w_dividers = None
         self._headers = headers
@@ -62,25 +82,48 @@ class TableDisplay:
 
     @property
     def cell_widths(self) -> List[int]:
+        """
+        List of cell widths of the table.  Length equal to the number
+        of columns, `ncols`.
+        """
         return self._cell_widths
 
     @property
-    def headers(self) -> List[str]:
+    def headers(self) -> List[str] | None:
+        """
+        List of table headers.  Length equal to the number of columns,
+        `ncols`.
+
+        `None` if table has no headers.
+        """
         return self._headers
 
     @property
     def rows(self) -> List[List[str]]:
+        """
+        List of table rows where each row is a list of strings being
+        the contents of the associated row-column cell.
+
+        For example, ``rows[4][3]`` would be the cell contents of row 5
+        and column 4.
+        """
         return self._rows
 
     @property
     def nrows(self) -> int:
+        """Number of rows in the table, excluding headers."""
         return len(self._rows)
 
     @property
     def ncols(self) -> int:
+        """Number of columns in the table."""
         return len(self._rows[0])
 
-    def _calc_max_cell_widths(self):
+    def _calc_max_cell_widths(self) -> List[int]:
+        """
+        Scans `rows` and `headers` to determine the maximum cell width
+        for each column.
+        """
         max_cel_widths = [len(entry) + 2 for entry in self.headers]
         for row in self.rows:
             for ii in range(len(max_cel_widths)):
@@ -89,6 +132,20 @@ class TableDisplay:
         return max_cel_widths
 
     def auto_insert_horizontal_dividers(self, on_columns: List[int]):
+        """
+        Automatically insert horizontal dividers into the table based
+        on cell value switching in columns specified by ``on_columns``.
+        Cell "switching" corresponds to when a cell value switches from
+        being empty to non-empty as moving down a column.  The
+        horizontal divider will be inserted above the non-empty cell
+        from the associated column to the end of the table.
+
+        Parameters
+        ----------
+        on_columns : List[int]
+            List of column indices to be used for determining where to
+            insert the horizontal divider.
+        """
 
         if not isinstance(on_columns, list):
             raise TypeError("on_column must be a int")
@@ -120,6 +177,10 @@ class TableDisplay:
         self._rows_w_dividers = _rows_w_dividers
 
     def table_string(self) -> str:
+        """
+        Generate and return the string contain the table associated with
+        `rows` and `headers`.
+        """
 
         table_string = ""
 

--- a/bapsflib/utils/__init__.py
+++ b/bapsflib/utils/__init__.py
@@ -40,6 +40,7 @@ class TableDisplay:
     `~bapsflib._hdf.maps.digitizers.map_digis.HDFMapDigitizers` and
     `~bapsflib._hdf.maps.controls.map_controls.HDFMapControls`.
     """
+
     def __init__(self, rows: List[List[str]], headers: List[str] | None = None):
         """
         Parameters

--- a/bapsflib/utils/tests/test_TableDisplay.py
+++ b/bapsflib/utils/tests/test_TableDisplay.py
@@ -113,3 +113,27 @@ class TestTableDisplay(ut.TestCase):
             with self.subTest(rows=rows, headers=headers, ncols=ncols):
                 tb = TableDisplay(rows, headers)
                 self.assertEqual(tb.ncols, ncols)
+
+    def test_auto_insert_horizontal_dividers_raises(self):
+        rows = [
+            ["one", "two", "three"],
+            ["four", "five", "six"],
+            ["seven", "eight", "nine"],
+        ]
+
+        cases = [
+            # (_raises, on_columns)
+            (TypeError, "not a list"),
+            (TypeError, 5),
+            # not all ints
+            (TypeError, [1, "not an int"]),
+            (TypeError, [1, 0.0]),
+        ]
+        for _raises, on_columns in cases:
+            with self.subTest(_raises=_raises, on_columns=on_columns):
+                td = TableDisplay(rows)
+                self.assertRaises(
+                    _raises,
+                    td.auto_insert_horizontal_dividers,
+                    on_columns=on_columns,
+                )

--- a/bapsflib/utils/tests/test_TableDisplay.py
+++ b/bapsflib/utils/tests/test_TableDisplay.py
@@ -1,0 +1,83 @@
+import unittest as ut
+
+from bapsflib.utils import TableDisplay
+
+
+class TestTableDisplay(ut.TestCase):
+
+    def test_raises(self):
+        cases = [
+            # (_raises, rows, headers)
+            (TypeError, "not a list", None),
+            (TypeError, None, None),
+            (TypeError, ["not a list of lists"], None),
+            (TypeError, [["one", "two"], ["three", "four"]], "not None or a list"),
+            # all contents of rows need to be strings
+            (ValueError, [["one", "two"], ["three", 4]], None),
+            # not equal columns between rows and headers
+            (ValueError, [["one", "two"], ["three", "four"]], ["col_1"]),
+            # all contents of headers need to be strings
+            (ValueError, [["one", "two"], ["three", "four"]], ["col_1", 2]),
+        ]
+        for _raises, rows, headers in cases:
+            with self.subTest(_raises=_raises, rows=rows, headers=headers):
+                self.assertRaises(
+                    _raises,
+                    TableDisplay,
+                    rows=rows,
+                    headers=headers,
+                )
+
+    def test_simple_table(self):
+        rows = [
+            ["one", "two", "three"],
+            ["four", "five", "six"],
+            ["seven", "eight", "nine"],
+        ]
+        expected = (
+            "| one   | two   | three |\n"
+            "| four  | five  | six   |\n"
+            "| seven | eight | nine  |\n"
+        )
+
+        td = TableDisplay(rows)
+        self.assertEqual(td.table_string(), expected)
+
+    def test_simple_table_w_headers(self):
+        rows = [
+            ["one", "two", "three"],
+            ["four", "five", "six"],
+            ["seven", "eight", "nine"],
+        ]
+        headers = ["col1", "col2", "col3"]
+        expected = (
+            "| col1  | col2  | col3  |\n"
+            "+-------+-------+-------+\n"
+            "| one   | two   | three |\n"
+            "| four  | five  | six   |\n"
+            "| seven | eight | nine  |\n"
+        )
+
+        td = TableDisplay(rows, headers)
+        self.assertEqual(td.table_string(), expected)
+
+    def test_cell_widths(self):
+        cases = [
+            # (rows, headers, expected_wdiths)
+            ([["one", "two", "three"]], None, [5, 5, 7]),
+            ([["one", "two", "three"]], ["col1", "2", "Really long"], [6, 5, 13]),
+            (
+                [["one", "eight", "three"], ["elephant", "ant", "fish"]],
+                None,
+                [10, 7, 7],
+            ),
+            (
+                [["one", "eight", "three"], ["elephant", "ant", "fish"]],
+                ["col1", "2", "Really long"],
+                [10, 7, 13],
+            ),
+        ]
+        for rows, headers, expected in cases:
+            with self.subTest(rows=rows, headers=headers, expected=expected):
+                tb = TableDisplay(rows, headers)
+                self.assertEqual(tb.cell_widths, expected)

--- a/bapsflib/utils/tests/test_TableDisplay.py
+++ b/bapsflib/utils/tests/test_TableDisplay.py
@@ -102,7 +102,11 @@ class TestTableDisplay(ut.TestCase):
             ([["one", "two", "three"], ["four", "five", "six"]], None, 3),
             ([["one", "two", "three"]], ["1", "2", "3"], 3),
             ([["one", "two", "three"], ["four", "five", "six"]], ["1", "2", "3"], 3),
-            ([["one",]], None, 1),
+            (
+                [["one"]],
+                None,
+                1,
+            ),
             ([["one", "two"]], None, 2),
         ]
         for rows, headers, ncols in cases:

--- a/bapsflib/utils/tests/test_TableDisplay.py
+++ b/bapsflib/utils/tests/test_TableDisplay.py
@@ -81,3 +81,31 @@ class TestTableDisplay(ut.TestCase):
             with self.subTest(rows=rows, headers=headers, expected=expected):
                 tb = TableDisplay(rows, headers)
                 self.assertEqual(tb.cell_widths, expected)
+
+    def test_nrows(self):
+        cases = [
+            # (rows, headers, nrows)
+            ([["one", "two", "three"]], None, 1),
+            ([["one", "two", "three"], ["four", "five", "six"]], None, 2),
+            ([["one", "two", "three"]], ["1", "2", "3"], 1),
+            ([["one", "two", "three"], ["four", "five", "six"]], ["1", "2", "3"], 2),
+        ]
+        for rows, headers, nrows in cases:
+            with self.subTest(rows=rows, headers=headers, nrows=nrows):
+                tb = TableDisplay(rows, headers)
+                self.assertEqual(tb.nrows, nrows)
+
+    def test_ncols(self):
+        cases = [
+            # (rows, headers, ncols)
+            ([["one", "two", "three"]], None, 3),
+            ([["one", "two", "three"], ["four", "five", "six"]], None, 3),
+            ([["one", "two", "three"]], ["1", "2", "3"], 3),
+            ([["one", "two", "three"], ["four", "five", "six"]], ["1", "2", "3"], 3),
+            ([["one",]], None, 1),
+            ([["one", "two"]], None, 2),
+        ]
+        for rows, headers, ncols in cases:
+            with self.subTest(rows=rows, headers=headers, ncols=ncols):
+                tb = TableDisplay(rows, headers)
+                self.assertEqual(tb.ncols, ncols)

--- a/bapsflib/utils/tests/test_TableDisplay.py
+++ b/bapsflib/utils/tests/test_TableDisplay.py
@@ -137,3 +137,85 @@ class TestTableDisplay(ut.TestCase):
                     td.auto_insert_horizontal_dividers,
                     on_columns=on_columns,
                 )
+
+    def test_auto_insert_vertical_dividers(self):
+        rows = [
+            ["one", "two", "three"],
+            ["", "", "six"],
+            ["", "eight", "nine"],
+            ["ten", "eleven", "twelve"],
+        ]
+        headers = ["col1", "col2", "col3" ]
+        td = TableDisplay(rows, headers)
+
+        cases = [
+            # (on_columns, expected)
+            (
+                [0, ],
+                (
+                    "| col1 | col2   | col3   |\n"
+                    "+------+--------+--------+\n"
+                    "| one  | two    | three  |\n"
+                    "|      |        | six    |\n"
+                    "|      | eight  | nine   |\n"
+                    "| ---- | ------ | ------ |\n"
+                    "| ten  | eleven | twelve |\n"
+                ),
+            ),
+            (
+                [0, 10, -1],
+                (
+                    "| col1 | col2   | col3   |\n"
+                    "+------+--------+--------+\n"
+                    "| one  | two    | three  |\n"
+                    "|      |        | six    |\n"
+                    "|      | eight  | nine   |\n"
+                    "| ---- | ------ | ------ |\n"
+                    "| ten  | eleven | twelve |\n"
+                ),
+            ),
+            (
+                [1, ],
+                (
+                    "| col1 | col2   | col3   |\n"
+                    "+------+--------+--------+\n"
+                    "| one  | two    | three  |\n"
+                    "|      |        | six    |\n"
+                    "|      | ------ | ------ |\n"
+                    "|      | eight  | nine   |\n"
+                    "|      | ------ | ------ |\n"
+                    "| ten  | eleven | twelve |\n"
+                ),
+            ),
+            (
+                [0, 1, ],
+                (
+                    "| col1 | col2   | col3   |\n"
+                    "+------+--------+--------+\n"
+                    "| one  | two    | three  |\n"
+                    "|      |        | six    |\n"
+                    "|      | ------ | ------ |\n"
+                    "|      | eight  | nine   |\n"
+                    "| ---- | ------ | ------ |\n"
+                    "| ten  | eleven | twelve |\n"
+                ),
+            ),
+            (
+                [10, ],
+                (
+                    "| col1 | col2   | col3   |\n"
+                    "+------+--------+--------+\n"
+                    "| one  | two    | three  |\n"
+                    "|      |        | six    |\n"
+                    "|      | eight  | nine   |\n"
+                    "| ten  | eleven | twelve |\n"
+                ),
+            )
+        ]
+        for on_columns, expected in cases:
+            with self.subTest(
+                rows=rows, headers=headers, on_columns=on_columns, expected=expected
+            ):
+                td._rows_w_dividers = None
+                td.auto_insert_horizontal_dividers(on_columns)
+                self.assertEqual(td.table_string(), expected)

--- a/bapsflib/utils/tests/test_TableDisplay.py
+++ b/bapsflib/utils/tests/test_TableDisplay.py
@@ -145,13 +145,15 @@ class TestTableDisplay(ut.TestCase):
             ["", "eight", "nine"],
             ["ten", "eleven", "twelve"],
         ]
-        headers = ["col1", "col2", "col3" ]
+        headers = ["col1", "col2", "col3"]
         td = TableDisplay(rows, headers)
 
         cases = [
             # (on_columns, expected)
             (
-                [0, ],
+                [
+                    0,
+                ],
                 (
                     "| col1 | col2   | col3   |\n"
                     "+------+--------+--------+\n"
@@ -175,7 +177,9 @@ class TestTableDisplay(ut.TestCase):
                 ),
             ),
             (
-                [1, ],
+                [
+                    1,
+                ],
                 (
                     "| col1 | col2   | col3   |\n"
                     "+------+--------+--------+\n"
@@ -188,7 +192,10 @@ class TestTableDisplay(ut.TestCase):
                 ),
             ),
             (
-                [0, 1, ],
+                [
+                    0,
+                    1,
+                ],
                 (
                     "| col1 | col2   | col3   |\n"
                     "+------+--------+--------+\n"
@@ -201,7 +208,9 @@ class TestTableDisplay(ut.TestCase):
                 ),
             ),
             (
-                [10, ],
+                [
+                    10,
+                ],
                 (
                     "| col1 | col2   | col3   |\n"
                     "+------+--------+--------+\n"
@@ -210,7 +219,7 @@ class TestTableDisplay(ut.TestCase):
                     "|      | eight  | nine   |\n"
                     "| ten  | eleven | twelve |\n"
                 ),
-            )
+            ),
         ]
         for on_columns, expected in cases:
             with self.subTest(

--- a/changelog/184.feature.1.rst
+++ b/changelog/184.feature.1.rst
@@ -1,0 +1,4 @@
+Added ``__str__`` and ``__repr__`` dunders to
+`~bapsflib._hdf.maps.digitizers.map_digis.HDFMapDigitizers` and
+`~bapsflib._hdf.maps.controls.map_controls.HDFMapControls` to display
+brief table summaries of the mapped devices.

--- a/changelog/184.feature.2.rst
+++ b/changelog/184.feature.2.rst
@@ -1,0 +1,4 @@
+Created `~bapsflib.utils.TableDisplay` to aid in generating table
+summaries for
+`~bapsflib._hdf.maps.digitizers.map_digis.HDFMapDigitizers` and
+`~bapsflib._hdf.maps.controls.map_controls.HDFMapControls`.

--- a/changelog/184.trivial.1.rst
+++ b/changelog/184.trivial.1.rst
@@ -1,0 +1,3 @@
+Forced mapped board and channel values for
+`~bapsflib._hdf.maps.digitizers.sis3301.HDFMapDigiSIS3301` to be type
+`int` instead of `numpy.integer`.


### PR DESCRIPTION
This PR defines the `__str__` and `__repr__` dunders for `HDFMapDigitizers` and `HDFMapControls`.  This is done so that `File.digitizers` and `File.controls` will output a table that displays a short summary of the mapping results.