### PR TITLE
Add validator methods to `HDFMapDigiTemplate`

### DIFF
--- a/bapsflib/_hdf/maps/digitizers/lecroy.py
+++ b/bapsflib/_hdf/maps/digitizers/lecroy.py
@@ -473,9 +473,7 @@ class HDFMapDigiLeCroy180E(HDFMapDigiTemplate):
             return dataset_name
 
         # get dataset info
-        _info = self.get_adc_info(
-            board, channel, config_name=config_name, adc=adc
-        )
+        _info = self.get_adc_info(board, channel, config_name=config_name, adc=adc)
         return dataset_name, _info
 
     def construct_header_dataset_name(

--- a/bapsflib/_hdf/maps/digitizers/lecroy.py
+++ b/bapsflib/_hdf/maps/digitizers/lecroy.py
@@ -8,7 +8,7 @@ __all__ = ["HDFMapDigiLeCroy180E"]
 import h5py
 import numpy as np
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 from warnings import warn
 
 from bapsflib._hdf.maps.digitizers.templates import HDFMapDigiTemplate

--- a/bapsflib/_hdf/maps/digitizers/lecroy.py
+++ b/bapsflib/_hdf/maps/digitizers/lecroy.py
@@ -458,19 +458,10 @@ class HDFMapDigiLeCroy180E(HDFMapDigiTemplate):
                 'shot average (software)': int,
             }
         """
-        # Condition config_name
+        # Condition config_name and adc
         # - if config_name is not specified then the 'active' config
         #   is sought out
-        config_name = self.validate_config_name(config_name)
-
-        # Condition adc keyword
-        if adc is None:
-            adc = "lecroy"
-        elif adc != "lecroy":
-            raise ValueError(
-                f"The only valid `adc` value is 'lecroy'.  Use 'lecroy' "
-                f"or omit optional keyword argument 'adc'."
-            )
+        config_name, adc = self.validate_config_name_and_adc(config_name, adc)
 
         # Condition board
         if board != 0:

--- a/bapsflib/_hdf/maps/digitizers/lecroy.py
+++ b/bapsflib/_hdf/maps/digitizers/lecroy.py
@@ -461,13 +461,7 @@ class HDFMapDigiLeCroy180E(HDFMapDigiTemplate):
         # Condition config_name
         # - if config_name is not specified then the 'active' config
         #   is sought out
-        if config_name is None:
-            config_name = "lecroy"
-        elif config_name != "lecroy":
-            raise ValueError(
-                f"The only valid `config_name` value is 'lecroy'.  Use 'lecroy' "
-                f"or omit optional keyword argument 'config_name'."
-            )
+        config_name = self.validate_config_name(config_name)
 
         # Condition adc keyword
         if adc is None:

--- a/bapsflib/_hdf/maps/digitizers/lecroy.py
+++ b/bapsflib/_hdf/maps/digitizers/lecroy.py
@@ -458,55 +458,25 @@ class HDFMapDigiLeCroy180E(HDFMapDigiTemplate):
                 'shot average (software)': int,
             }
         """
-        # Condition config_name and adc
-        # - if config_name is not specified then the 'active' config
-        #   is sought out
-        config_name, adc = self.validate_config_name_and_adc(config_name, adc)
+        # Validate digitizer parameters
+        board, channel, config_name, adc = self.validate_board_and_channel(
+            board=board,
+            channel=channel,
+            config_name=config_name,
+            adc=adc,
+        )
 
-        # Condition board
-        if board != 0:
-            raise ValueError(
-                f"The only valid `board` value is '0' (the int zero).  Use 'lecroy' "
-                f"or omit optional keyword argument 'adc'."
-            )
-
-        # Condition channel
-        if channel not in (1, 2, 3, 4):
-            raise ValueError(
-                f"Got value {channel} for argument `channel`, but only values "
-                f"1, 2, 3, or 4 are accepted."
-            )
-
-        # search if (board, channel) combo is connected
-        bc_valid = False
-        d_info = None
-        for brd, chs, extras in self._configs[config_name][adc]:
-            if channel in chs:
-                # board, channel combo valid
-                bc_valid = True
-
-                # save adc settings for return if requested
-                if return_info:
-                    d_info = extras.copy()
-                    d_info["adc"] = "lecroy"
-                    d_info["configuration name"] = config_name
-                    d_info["digitizer"] = self._info["group name"]
-                break
-
-        # (board, channel) combo must be active
-        if not bc_valid:
-            raise ValueError(
-                "Input `board` and `channel` do NOT specified a valid dataset."
-            )
-
-        # checks passed, build dataset_name
+        # build dataset_name
         dataset_name = f"Channel{channel}"
 
-        # return
-        if return_info:
-            return dataset_name, d_info
-        else:
+        if not return_info:
             return dataset_name
+
+        # get dataset info
+        _info = self.get_adc_info(
+            board, channel, config_name=config_name, adc=adc
+        )
+        return dataset_name, _info
 
     def construct_header_dataset_name(
         self, board: int, channel: int, config_name="lecroy", adc="lecroy", **kwargs

--- a/bapsflib/_hdf/maps/digitizers/sis3301.py
+++ b/bapsflib/_hdf/maps/digitizers/sis3301.py
@@ -789,26 +789,7 @@ class HDFMapDigiSIS3301(HDFMapDigiTemplate):
         # Condition config_name
         # - if config_name is not specified then the 'active' config
         #   is sought out
-        if config_name is None:
-            if len(self.active_configs) == 1:
-                config_name = self.active_configs[0]
-                warn(
-                    f"`config_name` not specified, assuming '{config_name}'.",
-                    HDFMappingWarning,
-                )
-            elif len(self.active_configs) > 1:
-                raise ValueError(
-                    "There are multiple active digitizer "
-                    "configurations...`config_name` kwarg must be "
-                    "specified."
-                )
-            else:
-                raise ValueError("No active digitizer configuration detected.")
-        elif config_name not in self._configs:
-            # config_name must be a known configuration
-            raise ValueError("Invalid `config_name` given.")
-        elif self._configs[config_name]["active"] is False:
-            raise ValueError("Specified configuration name `config_name` is not active.")
+        config_name = self.validate_config_name(config_name)
 
         # Condition adc keyword
         if adc != "SIS 3301":

--- a/bapsflib/_hdf/maps/digitizers/sis3301.py
+++ b/bapsflib/_hdf/maps/digitizers/sis3301.py
@@ -786,41 +786,25 @@ class HDFMapDigiSIS3301(HDFMapDigiTemplate):
                 'shot average (software)': int,
             }
         """
-        # Condition config_name and adc
-        # - if config_name is not specified then the 'active' config
-        #   is sought out
-        config_name, adc = self.validate_config_name_and_adc(config_name, adc)
+        # Validate digitizer parameters
+        board, channel, config_name, adc = self.validate_board_and_channel(
+            board=board,
+            channel=channel,
+            config_name=config_name,
+            adc=adc,
+        )
 
-        # search if (board, channel) combo is connected
-        bc_valid = False
-        d_info = None
-        for brd, chs, extras in self._configs[config_name]["SIS 3301"]:
-            if board == brd and channel in chs:
-                # board, channel combo valid
-                bc_valid = True
-
-                # save adc settings for return if requested
-                if return_info:
-                    d_info = extras.copy()
-                    d_info["adc"] = "SIS 3301"
-                    d_info["configuration name"] = config_name
-                    d_info["digitizer"] = self._info["group name"]
-                break
-
-        # (board, channel) combo must be active
-        if not bc_valid:
-            raise ValueError(
-                "Input `board` and `channel` do NOT specified a valid dataset."
-            )
-
-        # checks passed, build dataset_name
+        # build dataset_name
         dataset_name = f"{config_name} [{board}:{channel}]"
 
-        # return
-        if return_info is True:
-            return dataset_name, d_info
-        else:
+        if not return_info:
             return dataset_name
+
+        # get dataset info
+        _info = self.get_adc_info(
+            board, channel, config_name=config_name, adc=adc
+        )
+        return dataset_name, _info
 
     def construct_header_dataset_name(
         self, board: int, channel: int, config_name=None, adc="SIS 3301", **kwargs

--- a/bapsflib/_hdf/maps/digitizers/sis3301.py
+++ b/bapsflib/_hdf/maps/digitizers/sis3301.py
@@ -786,17 +786,10 @@ class HDFMapDigiSIS3301(HDFMapDigiTemplate):
                 'shot average (software)': int,
             }
         """
-        # Condition config_name
+        # Condition config_name and adc
         # - if config_name is not specified then the 'active' config
         #   is sought out
-        config_name = self.validate_config_name(config_name)
-
-        # Condition adc keyword
-        if adc != "SIS 3301":
-            raise ValueError(
-                f"Specified adc ({adc}) is not in specified configuration "
-                f"({config_name})."
-            )
+        config_name, adc = self.validate_config_name_and_adc(config_name, adc)
 
         # search if (board, channel) combo is connected
         bc_valid = False

--- a/bapsflib/_hdf/maps/digitizers/sis3301.py
+++ b/bapsflib/_hdf/maps/digitizers/sis3301.py
@@ -801,9 +801,7 @@ class HDFMapDigiSIS3301(HDFMapDigiTemplate):
             return dataset_name
 
         # get dataset info
-        _info = self.get_adc_info(
-            board, channel, config_name=config_name, adc=adc
-        )
+        _info = self.get_adc_info(board, channel, config_name=config_name, adc=adc)
         return dataset_name, _info
 
     def construct_header_dataset_name(

--- a/bapsflib/_hdf/maps/digitizers/sis3301.py
+++ b/bapsflib/_hdf/maps/digitizers/sis3301.py
@@ -21,7 +21,7 @@ import numpy as np
 import os
 import re
 
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Tuple
 from warnings import warn
 
 from bapsflib._hdf.maps.digitizers.templates import HDFMapDigiTemplate
@@ -691,7 +691,7 @@ class HDFMapDigiSIS3301(HDFMapDigiTemplate):
         return tuple(conn)
 
     @staticmethod
-    def _parse_config_name(name: str) -> Union[None, str]:
+    def _parse_config_name(name: str) -> str | None:
         """
         Parses ``name`` to determine the digitizer configuration
         name.  A configuration group name follows the format::
@@ -705,7 +705,7 @@ class HDFMapDigiSIS3301(HDFMapDigiTemplate):
 
         Returns
         -------
-        Union[None, str]
+        str | None
             digitizer configuration name, or `None` if ``name`` does
             not represent a configuration group
         """
@@ -735,7 +735,7 @@ class HDFMapDigiSIS3301(HDFMapDigiTemplate):
         config_name=None,
         adc="SIS 3301",
         return_info=False,
-    ) -> Union[str, Tuple[str, Dict[str, Any]]]:
+    ) -> str | Tuple[str, Dict[str, Any]]:
         """
         Construct the name of the HDF5 dataset containing digitizer
         data. The dataset name follows the format::
@@ -766,7 +766,7 @@ class HDFMapDigiSIS3301(HDFMapDigiTemplate):
 
         Returns
         -------
-        Union[str, Tuple[str, Dict[str, Any]]]
+        str | Tuple[str, Dict[str, Any]]
             digitizer dataset name. If ``return_info=True``, then
             returns a tuple of (dataset name, dictionary of meta-info)
 

--- a/bapsflib/_hdf/maps/digitizers/siscrate.py
+++ b/bapsflib/_hdf/maps/digitizers/siscrate.py
@@ -950,36 +950,15 @@ class HDFMapDigiSISCrate(HDFMapDigiTemplate):
                 'shot average (software)': int,
             }
         """
-        # Condition config_name
-        # - if config_name is not specified then the 'active' config
-        #   is sought out
-        #
-        # Condition adc
-        config_name, adc = self.validate_config_name_and_adc(config_name, adc)
+        # Validate digitizer parameters
+        board, channel, config_name, adc = self.validate_board_and_channel(
+            board=board,
+            channel=channel,
+            config_name=config_name,
+            adc=adc,
+        )
 
-        # search if (board, channel) combo is connected
-        bc_valid = False
-        d_info = None
-        for brd, chs, extras in self._configs[config_name][adc]:
-            if board == brd and channel in chs:
-                # board, channel combo valid
-                bc_valid = True
-
-                # save adc settings for return if requested
-                if return_info:
-                    d_info = extras.copy()
-                    d_info["adc"] = adc
-                    d_info["configuration name"] = config_name
-                    d_info["digitizer"] = self._info["group name"]
-                break
-
-        # (board, channel) combo must be active
-        if not bc_valid:
-            raise ValueError(
-                "Input `board` and `channel` do NOT specified a valid dataset."
-            )
-
-        # checks passed, build dataset_name
+        # build dataset_name
         slot = self.get_slot(board, adc)
         if adc == "SIS 3302":
             dataset_name = f"{config_name} [Slot {slot}: SIS 3302 ch {channel}]"
@@ -994,11 +973,14 @@ class HDFMapDigiSISCrate(HDFMapDigiTemplate):
 
             dataset_name = f"{config_name} [Slot {slot}: SIS 3305 FPGA {fpga} ch {ch}]"
 
-        # return
-        if return_info is True:
-            return dataset_name, d_info
-        else:
+        if not return_info:
             return dataset_name
+
+        # get dataset info
+        _info = self.get_adc_info(
+            board, channel, config_name=config_name, adc=adc
+        )
+        return dataset_name, _info
 
     def construct_header_dataset_name(
         self,

--- a/bapsflib/_hdf/maps/digitizers/siscrate.py
+++ b/bapsflib/_hdf/maps/digitizers/siscrate.py
@@ -953,33 +953,24 @@ class HDFMapDigiSISCrate(HDFMapDigiTemplate):
         # Condition config_name
         # - if config_name is not specified then the 'active' config
         #   is sought out
-        config_name = self.validate_config_name(config_name)
-
+        #
         # Condition adc
         # - if adc is not specified then the slow adc '3302' is assumed
         #   or, if 3305 is the only active adc, then it is assumed
         # - self.__config_crates() always adds 'SIS 3302' first. If
         #   '3302' is not active then the list will only contain '3305'.
-        if adc is None:
-            if len(self.configs[config_name]["adc"]) == 1:
-                adc = self.configs[config_name]["adc"][0]
-                warn(
-                    f"No `adc` specified, but only one adc used..."
-                    f"assuming adc '{adc}'",
-                    HDFMappingWarning,
-                )
-            else:
-                # there should never be a case where there are NO active
-                # adc's, this covers the case where there is MULTIPLE
-                # adc's
-                #
+        try:
+            config_name, adc = self.validate_config_name_and_adc(config_name, adc)
+        except ValueError:
+            if adc is not None:
+                raise
+
+            if adc is None:
+                # let's assume there is only one active adc 'SIS 3302' and
+                # try again
                 adc = "SIS 3302"
+                config_name, adc = self.validate_config_name_and_adc(config_name, adc)
                 warn("No `adc` specified...assuming adc 'SIS 3302'", HDFMappingWarning)
-        elif adc not in self._configs[config_name]["adc"]:
-            raise ValueError(
-                f"Specified adc ({adc}) is not in specified configuration "
-                f"({config_name})."
-            )
 
         # search if (board, channel) combo is connected
         bc_valid = False

--- a/bapsflib/_hdf/maps/digitizers/siscrate.py
+++ b/bapsflib/_hdf/maps/digitizers/siscrate.py
@@ -953,26 +953,7 @@ class HDFMapDigiSISCrate(HDFMapDigiTemplate):
         # Condition config_name
         # - if config_name is not specified then the 'active' config
         #   is sought out
-        if config_name is None:
-            if len(self.active_configs) == 1:
-                config_name = self.active_configs[0]
-                warn(
-                    f"`config_name` not specified, assuming '{config_name}'.",
-                    HDFMappingWarning,
-                )
-            elif len(self.active_configs) > 1:
-                raise ValueError(
-                    "There are multiple active digitizer "
-                    "configurations...`config_name` kwarg must be "
-                    "specified."
-                )
-            else:
-                raise ValueError("No active digitizer configuration detected.")
-        elif config_name not in self._configs:
-            # config_name must be a known configuration
-            raise ValueError("Invalid `config_name` given.")
-        elif self._configs[config_name]["active"] is False:
-            raise ValueError("Specified configuration name `config_name` is not active.")
+        config_name = self.validate_config_name(config_name)
 
         # Condition adc
         # - if adc is not specified then the slow adc '3302' is assumed

--- a/bapsflib/_hdf/maps/digitizers/siscrate.py
+++ b/bapsflib/_hdf/maps/digitizers/siscrate.py
@@ -989,7 +989,7 @@ class HDFMapDigiSISCrate(HDFMapDigiTemplate):
                 break
 
         # (board, channel) combo must be active
-        if bc_valid is False:
+        if not bc_valid:
             raise ValueError(
                 "Input `board` and `channel` do NOT specified a valid dataset."
             )

--- a/bapsflib/_hdf/maps/digitizers/siscrate.py
+++ b/bapsflib/_hdf/maps/digitizers/siscrate.py
@@ -977,9 +977,7 @@ class HDFMapDigiSISCrate(HDFMapDigiTemplate):
             return dataset_name
 
         # get dataset info
-        _info = self.get_adc_info(
-            board, channel, config_name=config_name, adc=adc
-        )
+        _info = self.get_adc_info(board, channel, config_name=config_name, adc=adc)
         return dataset_name, _info
 
     def construct_header_dataset_name(

--- a/bapsflib/_hdf/maps/digitizers/siscrate.py
+++ b/bapsflib/_hdf/maps/digitizers/siscrate.py
@@ -20,7 +20,7 @@ import h5py
 import numpy as np
 import re
 
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Tuple
 from warnings import warn
 
 from bapsflib._hdf.maps.digitizers.templates import HDFMapDigiTemplate
@@ -849,7 +849,7 @@ class HDFMapDigiSISCrate(HDFMapDigiTemplate):
         return nshotnum, nt
     """
 
-    def _parse_config_name(self, name: str) -> Union[None, str]:
+    def _parse_config_name(self, name: str) -> str | None:
         """
         Parses ``name`` to determine the digitizer configuration
         name.  A configuration group name follows the format::
@@ -863,7 +863,7 @@ class HDFMapDigiSISCrate(HDFMapDigiTemplate):
 
         Returns
         -------
-        Union[None, str]
+        str | None
             digitizer configuration name, or `None` if  ``name`` does
             not represent a configuration group
 
@@ -890,7 +890,7 @@ class HDFMapDigiSISCrate(HDFMapDigiTemplate):
 
     def construct_dataset_name(
         self, board: int, channel: int, config_name=None, adc=None, return_info=False
-    ) -> Union[str, Tuple[str, Dict[str, Any]]]:
+    ) -> str | Tuple[str, Dict[str, Any]]:
         """
         Construct the name of the HDF5 dataset containing digitizer
         data. The dataset naming follows two formats based on their
@@ -928,7 +928,7 @@ class HDFMapDigiSISCrate(HDFMapDigiTemplate):
 
         Returns
         -------
-        Union[str, Tuple[str, Dict[str, Any]]]
+        str | Tuple[str, Dict[str, Any]]
             digitizer dataset name. If ``return_info=True``,
             then returns a tuple of (dataset name, dictionary of
             meta-info)
@@ -1067,7 +1067,7 @@ class HDFMapDigiSISCrate(HDFMapDigiTemplate):
         dheader_name = f"{dset_name} headers"
         return dheader_name
 
-    def get_slot(self, brd: int, adc: str) -> Union[None, int]:
+    def get_slot(self, brd: int, adc: str) -> int | None:
         """
         Get slot number for given board number and adc.
 
@@ -1080,7 +1080,7 @@ class HDFMapDigiSISCrate(HDFMapDigiTemplate):
 
         Returns
         -------
-        Union[None, int]
+        int | None
             slot number, or `None` if there is no associated slot number
         """
         slot = None

--- a/bapsflib/_hdf/maps/digitizers/siscrate.py
+++ b/bapsflib/_hdf/maps/digitizers/siscrate.py
@@ -955,22 +955,7 @@ class HDFMapDigiSISCrate(HDFMapDigiTemplate):
         #   is sought out
         #
         # Condition adc
-        # - if adc is not specified then the slow adc '3302' is assumed
-        #   or, if 3305 is the only active adc, then it is assumed
-        # - self.__config_crates() always adds 'SIS 3302' first. If
-        #   '3302' is not active then the list will only contain '3305'.
-        try:
-            config_name, adc = self.validate_config_name_and_adc(config_name, adc)
-        except ValueError:
-            if adc is not None:
-                raise
-
-            if adc is None:
-                # let's assume there is only one active adc 'SIS 3302' and
-                # try again
-                adc = "SIS 3302"
-                config_name, adc = self.validate_config_name_and_adc(config_name, adc)
-                warn("No `adc` specified...assuming adc 'SIS 3302'", HDFMappingWarning)
+        config_name, adc = self.validate_config_name_and_adc(config_name, adc)
 
         # search if (board, channel) combo is connected
         bc_valid = False

--- a/bapsflib/_hdf/maps/digitizers/templates.py
+++ b/bapsflib/_hdf/maps/digitizers/templates.py
@@ -629,6 +629,76 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
 
         return config_name, adc
 
+    def validate_board_and_channel(
+        self,
+        board: int,
+        channel: int,
+        config_name: str | None = None,
+        adc: str | None = None,
+        allow_inactive: bool = False,
+    ):
+        """
+        Parameters
+        ----------
+        board : `int`
+            Board Number
+
+        channel : `int`
+            Channel Number
+
+        config_name : `str` or None
+            The ``config_name`` to be validated.  If `None` and only
+            one active configuration is present, then the active
+            configuration name will be assumed.
+
+        adc : `str` or None
+            The ``adc`` to be validated.  If `None` and only one
+            operable analog-digital-converter present, then the single
+            adc will be assumed.
+
+        allow_inactive : bool, optional
+            If `True`, then allow an inactive configuration to pass
+            validation.  An `HDFMappingWaring` will be given instead of
+            raising a `ValueError`.  (DEFAULT: `False`)
+
+        Returns
+        -------
+        board : int
+            Validated board number.
+
+        channel : int
+            Validated channel number.
+
+        config_name
+            A validated, and active, configuration name.
+
+        adc
+            A validated, and active, analog-digital-converter name.
+
+        See Also
+        --------
+        validate_config_namd, validate_config_name_and_adc
+        """
+        config_name, adc = self.validate_config_name_and_adc(
+            config_name=config_name, adc=adc, allow_inactive=allow_inactive
+        )
+
+        # search if (board, channel) combo is connected
+        bc_valid = False
+        for brd, chs, extras in self.configs[config_name][adc]:
+            if board == brd and channel in chs:
+                bc_valid = True
+                break
+
+        # (board, channel) combo must be active
+        if not bc_valid:
+            raise ValueError(
+                f"Input `board` ({board}) and `channel` ({channel}) do NOT "
+                f"specify a valid dataset."
+            )
+
+        return board, channel, config_name, adc
+
 
 HDFMapDigiTemplate.configs.__doc__ = (
     getdoc(HDFMapTemplate.configs) + "\n\n" + getdoc(HDFMapDigiTemplate.configs)

--- a/bapsflib/_hdf/maps/digitizers/templates.py
+++ b/bapsflib/_hdf/maps/digitizers/templates.py
@@ -609,7 +609,7 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
                 f"configuration has multiple adcs, "
                 f"{tuple(self.configs[config_name]['adc'])}."
             )
-        elif adc not in self._configs[config_name]["adc"]:
+        elif adc not in self.configs[config_name]["adc"]:
             raise ValueError(
                 f"Specified adc ({adc}) is not in specified configuration "
                 f"({config_name})."

--- a/bapsflib/_hdf/maps/digitizers/templates.py
+++ b/bapsflib/_hdf/maps/digitizers/templates.py
@@ -464,7 +464,7 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
             # This should never happen, since validate_board_and_channel()
             # should always identify a valid set.
             raise ValueError(
-                f"No valid info set identified using the given paramers: "
+                f"No valid info set identified using the given parameters: "
                 f" board = {board}, channel = {channel}, "
                 f"config_name = {config_name}, adc = {adc}"
             )
@@ -485,7 +485,9 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
         return adc_info
 
     def validate_config_name(
-        self, config_name: str | None, allow_inactive: bool = False,
+        self,
+        config_name: str | None,
+        allow_inactive: bool = False,
     ):
         """
         Validate the specified ``config_name`` to determine if it is

--- a/bapsflib/_hdf/maps/digitizers/templates.py
+++ b/bapsflib/_hdf/maps/digitizers/templates.py
@@ -411,8 +411,9 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
         self,
         board: int,
         channel: int,
-        adc: str = None,
+        *,
         config_name: str = None,
+        adc: str = None,
     ) -> Dict[str, Any]:
         """
         Get adc setup info dictionary associated with **board** and
@@ -438,54 +439,48 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
             dictionary of adc setup info (bit, clock rate, averaging,
             etc.) associated with **board** and **channel**
         """
-        # look for `config_name`
-        if config_name is None:
-            if len(self.active_configs) == 1:
-                config_name = self.active_configs[0]
-                warn(
-                    f"`config_name` not specified, assuming '{config_name}'",
-                    HDFMappingWarning,
-                )
-            else:
-                raise ValueError("A valid `config_name` needs to be specified")
-        elif self.configs[config_name]["active"] is False:
-            warn(
-                f"Digitizer configuration '{config_name}' is not actively used.",
-                HDFMappingWarning,
-            )
-
-        # look for `adc`
-        if adc is None:
-            if len(self.configs[config_name]["adc"]) == 1:
-                adc = self.configs[config_name]["adc"][0]
-                warn(f"`adc` not specified, assuming '{adc}'", HDFMappingWarning)
-            else:
-                raise ValueError("A valid `adc` needs to be specified")
+        board, channel, config_name, adc = self.validate_board_and_channel(
+            board=board,
+            channel=channel,
+            config_name=config_name,
+            adc=adc,
+            allow_inactive=True,
+        )
 
         # look for `board`
         adc_setup = self.configs[config_name][adc]
-        found = False
-        conn = (None, None, None)
+        adc_info = None  # type: Dict[str, Any] | None
         for conn in adc_setup:
-            if board == conn[0]:
-                found = True
-                break
-        if not found:
-            raise ValueError(f"Board number ({board}) not found in setup")
+            if board != conn[0]:
+                continue
 
-        # look for `channel`
-        if channel not in conn[1]:
-            raise ValueError(f"Channel number ({channel})  not found in setup")
+            if channel not in conn[1]:
+                continue
+
+            adc_info = copy.deepcopy(conn[2])
+            break
+
+        if adc_info is None:  # pragma: no cover
+            # This should never happen, since validate_board_and_channel()
+            # should always identify a valid set.
+            raise ValueError(
+                f"No valid info set identified using the given paramers: "
+                f" board = {board}, channel = {channel}, "
+                f"config_name = {config_name}, adc = {adc}"
+            )
 
         # get dictionary and add keys
         # - 'board', 'channel', 'adc', 'digitizer', and
         #   'configuration name'
-        adc_info = copy.deepcopy(conn[2])
-        adc_info["adc"] = adc
-        adc_info["board"] = board
-        adc_info["channel"] = channel
-        adc_info["configuration name"] = config_name
-        adc_info["digitizer"] = self.device_name
+        adc_info.update(
+            {
+                "board": board,
+                "channel": channel,
+                "configuration name": config_name,
+                "digitizer": self.device_name,
+                "adc": adc,
+            },
+        )
 
         return adc_info
 

--- a/bapsflib/_hdf/maps/digitizers/templates.py
+++ b/bapsflib/_hdf/maps/digitizers/templates.py
@@ -557,7 +557,12 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
 
         return config_name
 
-    def validate_config_name_and_adc(self, config_name: str | None, adc: str | None):
+    def validate_config_name_and_adc(
+        self,
+        config_name: str | None,
+        adc: str | None,
+        allow_inactive: bool = False,
+    ):
         """
         Validate the specified ``config_name`` and ``adc`` name to
         determine if the set is present and active in the digitizer
@@ -583,6 +588,11 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
             operable analog-digital-converter present, then the single
             adc will be assumed.
 
+        allow_inactive : bool, optional
+            If `True`, then allow an inactive configuration to pass
+            validation.  An `HDFMappingWaring` will be given instead of
+            raising a `ValueError`.  (DEFAULT: `False`)
+
         Return
         ------
         config_name
@@ -595,7 +605,9 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
         --------
         validate_config_name, validate_board_and_channel
         """
-        config_name = self.validate_config_name(config_name)
+        config_name = self.validate_config_name(
+            config_name, allow_inactive=allow_inactive
+        )
 
         if adc is None and len(self.configs[config_name]["adc"]) == 1:
             adc = self.configs[config_name]["adc"][0]

--- a/bapsflib/_hdf/maps/digitizers/templates.py
+++ b/bapsflib/_hdf/maps/digitizers/templates.py
@@ -489,6 +489,53 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
 
         return adc_info
 
+    def validate_config_name(self, config_name: str | None):
+        """
+        Validate the specified ``config_name`` to determine if it is
+        present and active in the digitizer acquisition.  If `None` and
+        there is only one active configuration, then the active
+        configuration name will be returned.
+
+        Parameters
+        ----------
+        config_name : `str` or None
+            The ``config_name`` to be validated.  If `None` and only
+            one active configuration is present, then the active
+            configuration name will be assumed.
+
+        Return
+        ------
+        config_name
+            A validated, and active, configuration name.
+        """
+        _active_configs = self.active_configs
+
+        # Condition config_name
+        # - if config_name is not specified then the 'active' config
+        #   is sought out
+        if config_name is None:
+            if len(_active_configs) == 1:
+                config_name = _active_configs[0]
+                warn(
+                    f"`config_name` not specified, assuming '{config_name}'.",
+                    HDFMappingWarning,
+                )
+            elif len(_active_configs) > 1:
+                raise ValueError(
+                    "There are multiple active digitizer "
+                    "configurations...`config_name` kwarg must be "
+                    "specified."
+                )
+            else:
+                raise ValueError("No active digitizer configuration detected.")
+        elif config_name not in _active_configs:
+            raise ValueError(
+                f"Invalid `config_name` given.  Valid `config_name` values "
+                f"are {_active_configs}."
+            )
+
+        return config_name
+
 
 HDFMapDigiTemplate.configs.__doc__ = (
     getdoc(HDFMapTemplate.configs) + "\n\n" + getdoc(HDFMapDigiTemplate.configs)

--- a/bapsflib/_hdf/maps/digitizers/templates.py
+++ b/bapsflib/_hdf/maps/digitizers/templates.py
@@ -575,8 +575,7 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
         if adc is None and len(self.configs[config_name]["adc"]) == 1:
             adc = self.configs[config_name]["adc"][0]
             warn(
-                f"No `adc` specified, but only one adc used..."
-                f"assuming adc '{adc}'",
+                f"No `adc` specified, but only one adc used...assuming adc '{adc}'",
                 HDFMappingWarning,
             )
         elif adc is None:

--- a/bapsflib/_hdf/maps/digitizers/templates.py
+++ b/bapsflib/_hdf/maps/digitizers/templates.py
@@ -518,6 +518,10 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
         ------
         config_name
             A validated, and active, configuration name.
+
+        See Also
+        --------
+        validate_config_name_and_adc, validate_board_and_channel
         """
         _active_configs = self.active_configs
 
@@ -586,6 +590,10 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
 
         adc
             A validated, and active, analog-digital-converter name.
+
+        See Also
+        --------
+        validate_config_name, validate_board_and_channel
         """
         config_name = self.validate_config_name(config_name)
 

--- a/bapsflib/_hdf/maps/digitizers/templates.py
+++ b/bapsflib/_hdf/maps/digitizers/templates.py
@@ -489,12 +489,18 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
 
         return adc_info
 
-    def validate_config_name(self, config_name: str | None):
+    def validate_config_name(
+        self, config_name: str | None, allow_inactive: bool = False,
+    ):
         """
         Validate the specified ``config_name`` to determine if it is
         present and active in the digitizer acquisition.  If `None` and
         there is only one active configuration, then the active
         configuration name will be returned.
+
+        If ``allow_inactive`` is `True`, then an `HDFMappingWarning`
+        will be issued instead of raising a `ValueError` when the
+        configuration is inactive.
 
         Parameters
         ----------
@@ -502,6 +508,11 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
             The ``config_name`` to be validated.  If `None` and only
             one active configuration is present, then the active
             configuration name will be assumed.
+
+        allow_inactive : bool, optional
+            If `True`, then allow an inactive configuration to pass
+            validation.  An `HDFMappingWarning` will be given instead of
+            raising a `ValueError`.  (DEFAULT: `False`)
 
         Return
         ------
@@ -529,9 +540,15 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
             else:
                 raise ValueError("No active digitizer configuration detected.")
         elif config_name not in _active_configs:
-            raise ValueError(
-                f"Invalid `config_name` given.  Valid `config_name` values "
-                f"are {_active_configs}."
+            if not allow_inactive:
+                raise ValueError(
+                    f"Invalid `config_name` given.  Valid `config_name` values "
+                    f"are {_active_configs}."
+                )
+
+            warn(
+                f"Digitizer configuration '{config_name}' is not actively used.",
+                HDFMappingWarning,
             )
 
         return config_name

--- a/bapsflib/_hdf/maps/digitizers/templates.py
+++ b/bapsflib/_hdf/maps/digitizers/templates.py
@@ -536,6 +536,63 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
 
         return config_name
 
+    def validate_config_name_and_adc(self, config_name: str | None, adc: str | None):
+        """
+        Validate the specified ``config_name`` and ``adc`` name to
+        determine if the set is present and active in the digitizer
+        acquisition.
+
+        If ``config_name`` is `None` and there is only one active
+        configuration, then the single active configuration will be
+        assumed.
+
+        If ``adc`` is `None` and the active configuration only has one
+        operable analog-digital-converter, then the single adc will be
+        assumed.
+
+        Parameters
+        ----------
+        config_name : `str` or None
+            The ``config_name`` to be validated.  If `None` and only
+            one active configuration is present, then the active
+            configuration name will be assumed.
+
+        adc : `str` or None
+            The ``adc`` to be validated.  If `None` and only one
+            operable analog-digital-converter present, then the single
+            adc will be assumed.
+
+        Return
+        ------
+        config_name
+            A validated, and active, configuration name.
+
+        adc
+            A validated, and active, analog-digital-converter name.
+        """
+        config_name = self.validate_config_name(config_name)
+
+        if adc is None and len(self.configs[config_name]["adc"]) == 1:
+            adc = self.configs[config_name]["adc"][0]
+            warn(
+                f"No `adc` specified, but only one adc used..."
+                f"assuming adc '{adc}'",
+                HDFMappingWarning,
+            )
+        elif adc is None:
+            raise ValueError(
+                f"Specify a desired `adc` to be validated.  The '{config_name}' "
+                f"configuration has multiple adcs, "
+                f"{tuple(self.configs[config_name]['adc'])}."
+            )
+        elif adc not in self._configs[config_name]["adc"]:
+            raise ValueError(
+                f"Specified adc ({adc}) is not in specified configuration "
+                f"({config_name})."
+            )
+
+        return config_name, adc
+
 
 HDFMapDigiTemplate.configs.__doc__ = (
     getdoc(HDFMapTemplate.configs) + "\n\n" + getdoc(HDFMapDigiTemplate.configs)

--- a/bapsflib/_hdf/maps/digitizers/templates.py
+++ b/bapsflib/_hdf/maps/digitizers/templates.py
@@ -454,8 +454,9 @@ class HDFMapDigiTemplate(HDFMapTemplate, ABC):
             if board != conn[0]:
                 continue
 
-            if channel not in conn[1]:
-                continue
+            # Note: check 'channel not in conn[1]' is NOT needed here
+            #       since validate_board_and_channel() has already conditioned
+            #       that channel is in conn[1].
 
             adc_info = copy.deepcopy(conn[2])
             break

--- a/bapsflib/_hdf/maps/digitizers/tests/test_siscrate.py
+++ b/bapsflib/_hdf/maps/digitizers/tests/test_siscrate.py
@@ -147,8 +147,8 @@ class TestSISCrate(DigitizerTestCase):
         brd = my_sabc[0][2]
         ch = my_sabc[0][3][0]
         dset_name = f"{config_name} [Slot {slot}: SIS 3302 ch {ch}]"
-        with self.assertWarns(HDFMappingWarning):
-            self.assertEqual(self.map.construct_dataset_name(brd, ch), dset_name)
+        with self.assertRaises(ValueError):
+            self.map.construct_dataset_name(brd, ch)
 
         # -- `board` and `channel` combo not in configs             ----
         brd = 5  # SIS 3302 only goes up to board 4
@@ -192,7 +192,7 @@ class TestSISCrate(DigitizerTestCase):
                 break
 
         # get dset_name
-        val = _map.construct_dataset_name(brd, ch, return_info=True)
+        val = _map.construct_dataset_name(brd, ch, adc="SIS 3302", return_info=True)
 
         self.assertIsInstance(val, tuple)
         self.assertEqual(len(val), 2)

--- a/changelog/196.feature.1.rst
+++ b/changelog/196.feature.1.rst
@@ -1,0 +1,5 @@
+.. py:currentmodule:: bapsflib._hdf.maps.digitizers.templates
+
+Add validation methods `~HDFMapDigiTemplate.validate_config_name`,
+`~HDFMapDigiTemplate.validate_config_name_and_adc`, and
+`~HDFMapDigiTemplate.validate_board_and_channel` to `HDFMapDigiTemplate`.

--- a/changelog/196.feature.1.rst
+++ b/changelog/196.feature.1.rst
@@ -1,5 +1,5 @@
 .. py:currentmodule:: bapsflib._hdf.maps.digitizers.templates
 
-Add validation methods `~HDFMapDigiTemplate.validate_config_name`,
+Added validation methods `~HDFMapDigiTemplate.validate_config_name`,
 `~HDFMapDigiTemplate.validate_config_name_and_adc`, and
 `~HDFMapDigiTemplate.validate_board_and_channel` to `HDFMapDigiTemplate`.

--- a/changelog/196.trivial.1.rst
+++ b/changelog/196.trivial.1.rst
@@ -1,0 +1,4 @@
+.. py:currentmodule:: bapsflib._hdf.maps.digitizers.templates
+
+Incorporated `HDFMapDigiTemplate.validate_board_and_channel` into
+to `~HDFMapDigiTemplate.get_adc_info`.

--- a/changelog/196.trivial.2.rst
+++ b/changelog/196.trivial.2.rst
@@ -1,0 +1,8 @@
+.. py:currentmodule:: bapsflib._hdf.maps.digitizers
+
+Streamlined the ``construct_dataset_name`` method for
+`~lecroy.HDFMapDigiLeCroy180E`, `~sis3301.HDFMapDigiSIS3301`, and
+`~siscrate.HDFMapDigiSISCrate` by incorporating
+`~templates.HDFMapDigiTemplate.validate_board_and_channel` for argument
+validation and `~templates.HDFMapDigiTemplate.get_adc_info` for
+generating the information dictionary.


### PR DESCRIPTION
This PR adds methods

- `validate_config_name`
- `validate_config_name_and_adc`
- `validate_board_and_channel`

to `HDFMapDigiTemplate`.  These methods are used by `construct_dataset_name()`, `construct_header_dataset_name()`, and `get_adc_info()`.  Adding this methods allow for:

- reducing code duplication, since inheriting methods can use this functionality instead of duplicating it
- exposes the functionality to the external user interface, so it can be used by other parts of the package (e.g. `HDFReadData`)

`construct_dataset_name` now generates its info dictionary using `get_adc_info()`.  This is all an effort to reduce code duplication, and ensure the meta-info is always being generated by the same set of code.